### PR TITLE
Fix workspace fetch loop and clean API CORS

### DIFF
--- a/api/workspaces_get.php
+++ b/api/workspaces_get.php
@@ -1,14 +1,4 @@
 <?php
-header('Access-Control-Allow-Origin: http://localhost:5173');
-header('Access-Control-Allow-Credentials: true');
-header('Access-Control-Allow-Headers: Content-Type, Authorization');
-header('Access-Control-Allow-Methods: GET, POST, PUT, DELETE, OPTIONS');
-
-if ($_SERVER['REQUEST_METHOD'] === 'OPTIONS') {
-    http_response_code(200);
-    exit;
-}
-
 require 'cors.php';
 require 'db.php';
 require 'auth_check.php'; // levert $user_id

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -127,19 +127,21 @@ const {
 useEffect(() => {
   if (!token) return;
 
-  fetchWorkspaces().then(() => {
+  (async () => {
+    const fetched = await fetchWorkspaces();
     const storedWorkspaceId = localStorage.getItem('vault_activeWorkspaceId');
-    const validStoredId = storedWorkspaceId && workspaces.some(w => w.id === parseInt(storedWorkspaceId, 10));
+    const validStoredId =
+      storedWorkspaceId && fetched.some(w => w.id === parseInt(storedWorkspaceId, 10));
 
     if (validStoredId) {
       setActiveWorkspaceId(parseInt(storedWorkspaceId, 10));
-    } else if (workspaces.length > 0) {
-      const fallbackId = workspaces[0].id;
+    } else if (fetched.length > 0) {
+      const fallbackId = fetched[0].id;
       setActiveWorkspaceId(fallbackId);
       localStorage.setItem('vault_activeWorkspaceId', fallbackId);
     }
-  });
-}, [token, fetchWorkspaces, workspaces]);
+  })();
+}, [token, fetchWorkspaces]);
 
 
 

--- a/src/hooks/useWorkspacesApi.js
+++ b/src/hooks/useWorkspacesApi.js
@@ -21,10 +21,12 @@ export function useWorkspacesApi(token, onToast) {
       if (!result.success) throw new Error(result.message || 'Failed to fetch workspaces');
 
       setWorkspaces(result.workspaces);
+      return result.workspaces;
     } catch (err) {
       setError(err.message);
       onToast?.('Error fetching workspaces');
       console.error(err);
+      return [];
     } finally {
       setLoading(false);
     }


### PR DESCRIPTION
## Summary
- simplify `workspaces_get.php` CORS handling
- ensure workspace fetching returns data for callers
- load workspaces once in `App` and set active workspace reliably

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 312 problems)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68922c74573883328022fee0a56907bc