### PR TITLE
Enhance login form layout and security

### DIFF
--- a/src/components/Input.jsx
+++ b/src/components/Input.jsx
@@ -9,6 +9,7 @@ const Input = forwardRef(function Input(
     placeholder = '',
     required = false,
     className = '',
+    ...props
   },
   ref
 ) {
@@ -23,6 +24,7 @@ const Input = forwardRef(function Input(
         placeholder={placeholder}
         required={required}
         className={`p-2 border rounded focus:outline-none focus:ring-2 focus:ring-blue-500 transition ${className}`}
+        {...props}
       />
     </div>
   );

--- a/src/components/LoginForm.jsx
+++ b/src/components/LoginForm.jsx
@@ -4,6 +4,9 @@ import Input from './Input';
 import Button from './Button';
 import Toast from './Toast';
 
+const BASE_URL =
+  import.meta.env.VITE_API_BASE_URL || 'http://localhost/persona-vault-web/api';
+
 export default function LoginForm({ onLoginSuccess }) {
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
@@ -16,10 +19,10 @@ export default function LoginForm({ onLoginSuccess }) {
     setError(null);
 
     try {
-      const response = await fetch(`${import.meta.env.VITE_API_BASE_URL || 'http://localhost/persona-vault-web/api'}/auth_login.php`, {
+      const response = await fetch(`${BASE_URL}/auth_login.php`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ email, password }),
+        body: JSON.stringify({ email: email.trim(), password }),
       });
 
       const data = await response.json();
@@ -42,28 +45,41 @@ export default function LoginForm({ onLoginSuccess }) {
 
   return (
     <div className="flex flex-col items-center justify-center min-h-screen bg-gradient-to-b from-gray-100 via-gray-50 to-white dark:from-gray-900 dark:via-gray-800 dark:to-gray-900 text-gray-900 dark:text-white px-4">
-      <div className="max-w-md w-full bg-white dark:bg-gray-800 shadow-lg rounded-lg p-6">
-        <h2 className="text-2xl font-bold mb-4 text-center text-gray-800 dark:text-gray-100">Login</h2>
+      <div className="w-full max-w-md bg-white dark:bg-gray-800 shadow-xl rounded-lg p-8 space-y-6">
+        <h2 className="text-3xl font-bold text-center text-gray-800 dark:text-gray-100">Login</h2>
 
         {error && <Toast message={error} onClose={() => setError(null)} />}
 
-        <form onSubmit={handleSubmit} className="flex flex-col space-y-4">
+        <form onSubmit={handleSubmit} className="flex flex-col space-y-5">
           <Input
-  label="Email or Username"
-  type="text"
-  value={email}
-  onChange={(e) => setEmail(e.target.value)}
-  required
-/>
+            label="Email or Username"
+            type="text"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            autoComplete="username"
+            required
+          />
 
           <Input
             label="Password"
             type="password"
             value={password}
             onChange={(e) => setPassword(e.target.value)}
+            autoComplete="current-password"
+            minLength={8}
             required
           />
-          <Button type="submit" disabled={loading}>
+
+          <div className="flex justify-end">
+            <a
+              href="#"
+              className="text-sm text-blue-600 hover:underline dark:text-blue-400"
+            >
+              Forgot password?
+            </a>
+          </div>
+
+          <Button type="submit" disabled={loading} className="w-full">
             {loading ? 'Logging in...' : 'Login'}
           </Button>
         </form>


### PR DESCRIPTION
## Summary
- allow `Input` component to forward additional props to underlying input
- modernize login form layout and add a "Forgot password?" link
- trim submitted email and enable browser autocomplete for credentials

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: 312 problems)*
- `npx eslint src/components/Input.jsx src/components/LoginForm.jsx`

------
https://chatgpt.com/codex/tasks/task_b_689232304a908332b0676705f6f9f8e7