### PR TITLE
feat: add admin panel for workspace management

### DIFF
--- a/api/admin_users_get.php
+++ b/api/admin_users_get.php
@@ -1,0 +1,18 @@
+<?php
+require 'cors.php';
+require 'db.php';
+require 'auth_check_admin.php';
+
+header('Content-Type: application/json');
+
+try {
+    $stmt = $pdo->query("SELECT id, username, email FROM users ORDER BY username ASC");
+    $users = $stmt->fetchAll(PDO::FETCH_ASSOC);
+    echo json_encode(['success' => true, 'users' => $users]);
+} catch (PDOException $e) {
+    http_response_code(500);
+    echo json_encode([
+        'success' => false,
+        'message' => 'Database error: ' . $e->getMessage()
+    ]);
+}

--- a/api/admin_workspace_create.php
+++ b/api/admin_workspace_create.php
@@ -1,0 +1,34 @@
+<?php
+require 'cors.php';
+require 'db.php';
+require 'auth_check_admin.php';
+
+header('Content-Type: application/json');
+
+$data = json_decode(file_get_contents('php://input'), true);
+$name = trim($data['name'] ?? '');
+$owner_id = $data['owner_id'] ?? null;
+
+if (!$name || !$owner_id) {
+    http_response_code(400);
+    echo json_encode(['success' => false, 'message' => 'Workspace name and owner_id are required']);
+    exit;
+}
+
+try {
+    $stmt = $pdo->prepare("INSERT INTO workspaces (name, owner_id) VALUES (?, ?)");
+    $stmt->execute([$name, $owner_id]);
+    $workspace_id = $pdo->lastInsertId();
+
+    // Voeg owner toe als admin member
+    $stmt = $pdo->prepare("INSERT INTO workspace_members (workspace_id, user_id, role) VALUES (?, ?, 'admin')");
+    $stmt->execute([$workspace_id, $owner_id]);
+
+    echo json_encode(['success' => true, 'workspace_id' => $workspace_id]);
+} catch (PDOException $e) {
+    http_response_code(500);
+    echo json_encode([
+        'success' => false,
+        'message' => 'Database error: ' . $e->getMessage()
+    ]);
+}

--- a/api/admin_workspace_delete.php
+++ b/api/admin_workspace_delete.php
@@ -1,0 +1,25 @@
+<?php
+require 'cors.php';
+require 'db.php';
+require 'auth_check_admin.php';
+
+header('Content-Type: application/json');
+
+$workspace_id = $_GET['id'] ?? null;
+if (!$workspace_id) {
+    http_response_code(400);
+    echo json_encode(['success' => false, 'message' => 'Workspace ID is required']);
+    exit;
+}
+
+try {
+    $stmt = $pdo->prepare("DELETE FROM workspaces WHERE id = ?");
+    $stmt->execute([$workspace_id]);
+    echo json_encode(['success' => true]);
+} catch (PDOException $e) {
+    http_response_code(500);
+    echo json_encode([
+        'success' => false,
+        'message' => 'Database error: ' . $e->getMessage()
+    ]);
+}

--- a/api/admin_workspaces_get_all.php
+++ b/api/admin_workspaces_get_all.php
@@ -1,0 +1,18 @@
+<?php
+require 'cors.php';
+require 'db.php';
+require 'auth_check_admin.php';
+
+header('Content-Type: application/json');
+
+try {
+    $stmt = $pdo->query("SELECT w.id, w.name, w.owner_id, w.created_at, u.username AS owner_username FROM workspaces w JOIN users u ON w.owner_id = u.id ORDER BY w.created_at DESC");
+    $workspaces = $stmt->fetchAll(PDO::FETCH_ASSOC);
+    echo json_encode(['success' => true, 'workspaces' => $workspaces]);
+} catch (PDOException $e) {
+    http_response_code(500);
+    echo json_encode([
+        'success' => false,
+        'message' => 'Database error: ' . $e->getMessage()
+    ]);
+}

--- a/api/auth_check_admin.php
+++ b/api/auth_check_admin.php
@@ -1,0 +1,13 @@
+<?php
+require_once 'auth_check.php'; // sets $user_id and $workspace_id
+
+// Controleer of gebruiker admin is
+$stmt = $pdo->prepare("SELECT is_admin FROM users WHERE id = ?");
+$stmt->execute([$user_id]);
+$is_admin = $stmt->fetchColumn();
+
+if (!$is_admin) {
+    http_response_code(403);
+    echo json_encode(['success' => false, 'message' => 'Admin privileges required']);
+    exit;
+}

--- a/api/auth_login.php
+++ b/api/auth_login.php
@@ -23,8 +23,8 @@ if (!$email || !$password) {
     exit;
 }
 
-// User ophalen
-$stmt = $pdo->prepare("SELECT id, username, password_hash FROM users WHERE email = ? OR username = ?");
+// User ophalen (inclusief admin-flag)
+$stmt = $pdo->prepare("SELECT id, username, password_hash, is_admin FROM users WHERE email = ? OR username = ?");
 $stmt->execute([$email, $email]);
 $user = $stmt->fetch(PDO::FETCH_ASSOC);
 
@@ -52,11 +52,12 @@ if (!$workspaceId) {
     exit;
 }
 
-// ✅ JWT genereren
+// ✅ JWT genereren (met admin-info)
 $token = generate_jwt([
     'user_id' => $user['id'],
     'username' => $user['username'],
-    'workspace_id' => $workspaceId
+    'workspace_id' => $workspaceId,
+    'is_admin' => (int)$user['is_admin']
 ], 3600 * 24 * 7);
 
 echo json_encode(['success' => true, 'token' => trim($token)]);

--- a/api/auth_register.php
+++ b/api/auth_register.php
@@ -42,8 +42,8 @@ if ($stmt->fetch()) {
 // Hash password
 $password_hash = password_hash($password, PASSWORD_DEFAULT);
 
-// Insert user
-$stmt = $pdo->prepare("INSERT INTO users (username, email, password_hash) VALUES (?, ?, ?)");
+// Insert user (default not admin)
+$stmt = $pdo->prepare("INSERT INTO users (username, email, password_hash, is_admin) VALUES (?, ?, ?, 0)");
 $stmt->execute([$username, $email, $password_hash]);
 
 $user_id = $pdo->lastInsertId();
@@ -61,7 +61,8 @@ $memberStmt->execute([$workspaceId, $user_id]);
 $token = generate_jwt([
     'user_id' => $user_id,
     'username' => $username,
-    'workspace_id' => $workspaceId
+    'workspace_id' => $workspaceId,
+    'is_admin' => 0
 ], 3600 * 24 * 7);
 
 echo json_encode(['success' => true, 'token' => $token]);

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -21,6 +21,7 @@ import FloatingInstallBanner from './components/FloatingInstallBanner';
 import TagFilterDropdown from './components/TagFilterDropdown';
 import QuickTitlesDropdown from './components/QuickTitlesDropdown.jsx';
 import ScrollToTopButton from './components/ScrollToTopButton';
+import AdminPanelModal from './components/AdminPanelModal';
 import CollectionDashboard from './pages/CollectionDashboard';
 import CollectionPage from './pages/CollectionPage';
 import Modal from './components/Modal';
@@ -41,6 +42,8 @@ function App() {
   const [isSettingsModalOpen, setIsSettingsModalOpen] = useState(false);
   const [editingPersona, setEditingPersona] = useState(null);
   const [isPersonaModalOpen, setIsPersonaModalOpen] = useState(false);
+  const [isAdminPanelOpen, setIsAdminPanelOpen] = useState(false);
+  const [isAdmin, setIsAdmin] = useState(false);
   const [activeCollectionId, setActiveCollectionId] = useState(() => {
   const storedId = localStorage.getItem('vault_activeCollectionId');
   
@@ -194,6 +197,7 @@ useEffect(() => {
       const decoded = jwtDecode(token);
       setDecodedToken(decoded);
       setUsername(decoded.username || decoded.email || 'User');
+      setIsAdmin(!!decoded.is_admin);
 
       if (!activeWorkspaceId && decoded.workspace_id) {
         setActiveWorkspaceId(decoded.workspace_id);
@@ -360,10 +364,12 @@ const handleUpdateTags = ({ action, targetTag, newTag, sourceTag }) => {
   onOpenProfile={() => setIsProfileModalOpen(true)}
   createPersona={createPersona} // ✅ toevoegen
   createPrompt={createPrompt}   // ✅ toevoegen
-  deletePersona={deletePersona}    // ✅ toevoegen
-  deletePrompt={deletePrompt} 
-  handleUpdateTags={handleUpdateTags}
-  
+    deletePersona={deletePersona}    // ✅ toevoegen
+    deletePrompt={deletePrompt}
+    handleUpdateTags={handleUpdateTags}
+    isAdmin={isAdmin}
+    onOpenAdminPanel={() => setIsAdminPanelOpen(true)}
+
 />
 
 {workspaces.length > 0 && (
@@ -706,6 +712,15 @@ token={token}
     onClose={() => setIsSettingsModalOpen(false)}
     compactMode={compactMode}
     setCompactMode={setCompactMode}
+  />
+)}
+
+{isAdminPanelOpen && (
+  <AdminPanelModal
+    isOpen={isAdminPanelOpen}
+    onClose={() => setIsAdminPanelOpen(false)}
+    token={token}
+    onToast={setGlobalToastMessage}
   />
 )}
 

--- a/src/components/AdminPanelModal.jsx
+++ b/src/components/AdminPanelModal.jsx
@@ -1,0 +1,115 @@
+import { useEffect, useState } from 'react';
+import { FiX, FiTrash, FiPlus } from 'react-icons/fi';
+import Button from './Button';
+import { useAdminApi } from '../hooks/useAdminApi';
+
+export default function AdminPanelModal({ isOpen, onClose, token, onToast }) {
+  const {
+    users,
+    workspaces,
+    fetchUsers,
+    fetchAllWorkspaces,
+    createWorkspaceForUser,
+    deleteWorkspace
+  } = useAdminApi(token, onToast);
+
+  const [workspaceName, setWorkspaceName] = useState('');
+  const [ownerId, setOwnerId] = useState('');
+
+  useEffect(() => {
+    if (isOpen) {
+      fetchUsers();
+      fetchAllWorkspaces();
+    }
+  }, [isOpen, fetchUsers, fetchAllWorkspaces]);
+
+  if (!isOpen) return null;
+
+  const handleCreate = async () => {
+    await createWorkspaceForUser(ownerId, workspaceName);
+    setWorkspaceName('');
+    setOwnerId('');
+  };
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 backdrop-blur-sm"
+      onClick={onClose}
+    >
+      <div
+        className="bg-white dark:bg-gray-900 p-6 rounded-xl shadow-xl w-full max-w-3xl space-y-6 relative"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <button
+          onClick={onClose}
+          className="absolute top-2 right-2 text-gray-400 hover:text-gray-600 dark:hover:text-gray-200"
+        >
+          <FiX className="text-xl" />
+        </button>
+
+        <h2 className="text-2xl font-bold text-gray-900 dark:text-white">Admin Panel</h2>
+
+        {/* Create workspace */}
+        <div className="space-y-2">
+          <h3 className="text-lg font-semibold">Create workspace</h3>
+          <div className="flex flex-col sm:flex-row sm:items-center gap-2">
+            <input
+              type="text"
+              value={workspaceName}
+              onChange={(e) => setWorkspaceName(e.target.value)}
+              placeholder="Workspace name"
+              className="flex-1 px-3 py-2 rounded-lg border dark:border-gray-700 bg-white dark:bg-gray-800"
+            />
+            <select
+              value={ownerId}
+              onChange={(e) => setOwnerId(e.target.value)}
+              className="px-3 py-2 rounded-lg border dark:border-gray-700 bg-white dark:bg-gray-800"
+            >
+              <option value="">Select user</option>
+              {users.map((u) => (
+                <option key={u.id} value={u.id}>
+                  {u.username}
+                </option>
+              ))}
+            </select>
+            <Button
+              variant="primary"
+              onClick={handleCreate}
+              disabled={!workspaceName || !ownerId}
+            >
+              <FiPlus className="mr-2" />
+              Create
+            </Button>
+          </div>
+        </div>
+
+        {/* Workspaces list */}
+        <div className="border-t border-gray-200 dark:border-gray-700 pt-4">
+          <h3 className="text-lg font-semibold mb-2">All workspaces</h3>
+          <ul className="space-y-2 max-h-64 overflow-y-auto pr-1">
+            {workspaces.map((w) => (
+              <li
+                key={w.id}
+                className="flex items-center justify-between bg-gray-100 dark:bg-gray-800 rounded-lg px-3 py-2"
+              >
+                <div>
+                  <div className="font-medium">{w.name}</div>
+                  <div className="text-sm text-gray-500">Owner: {w.owner_username}</div>
+                </div>
+                <button
+                  onClick={() => deleteWorkspace(w.id)}
+                  className="text-red-600 hover:text-red-800 dark:text-red-400 dark:hover:text-red-200"
+                >
+                  <FiTrash />
+                </button>
+              </li>
+            ))}
+            {workspaces.length === 0 && (
+              <li className="text-sm text-gray-500">No workspaces found</li>
+            )}
+          </ul>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -4,7 +4,7 @@ import DarkModeSwitch from './DarkModeSwitch';
 import AboutModal from './AboutModal';
 import SearchBar from './SearchBar';
 import { HiDotsVertical } from 'react-icons/hi';
-import { FiUpload, FiDownload, FiInfo, FiSettings, FiLogOut, FiUser } from 'react-icons/fi';
+import { FiUpload, FiDownload, FiInfo, FiSettings, FiLogOut, FiUser, FiShield } from 'react-icons/fi';
 import TagManagerModal from './TagManagerModal';
 import logoLight from '/logo-light.svg';
 import logoDark from '/logo-dark.svg';
@@ -23,8 +23,10 @@ export default function Header({
   fetchPrompts,
   deletePersona,
   deletePrompt,
-  handleUpdateTags, 
-  onLogout
+  handleUpdateTags,
+  onLogout,
+  isAdmin,
+  onOpenAdminPanel
 }) {
   const [isAboutOpen, setIsAboutOpen] = useState(false);
   const [mergeModalOpen, setMergeModalOpen] = useState(false);
@@ -181,6 +183,19 @@ export default function Header({
             </button>
           )}
         </Menu.Item>
+        {isAdmin && (
+          <Menu.Item>
+            {({ active }) => (
+              <button
+                onClick={onOpenAdminPanel}
+                className={`${active ? 'bg-gray-100 dark:bg-gray-700' : ''} group flex items-center w-full px-4 py-2 text-sm`}
+              >
+                <FiShield className="mr-3 w-5 h-5" />
+                Admin Panel
+              </button>
+            )}
+          </Menu.Item>
+        )}
         <Menu.Item>
           {({ active }) => (
             <button

--- a/src/hooks/useAdminApi.js
+++ b/src/hooks/useAdminApi.js
@@ -1,0 +1,91 @@
+import { useCallback, useState } from 'react';
+
+export function useAdminApi(token, onToast) {
+  const [users, setUsers] = useState([]);
+  const [workspaces, setWorkspaces] = useState([]);
+
+  const baseUrl = import.meta.env.VITE_API_BASE_URL;
+
+  const fetchUsers = useCallback(async () => {
+    try {
+      const res = await fetch(`${baseUrl}/admin_users_get.php`, {
+        headers: {
+          Authorization: `Bearer ${token}`
+        }
+      });
+      const data = await res.json();
+      if (!data.success) throw new Error(data.message || 'Failed to fetch users');
+      setUsers(data.users);
+      return data.users;
+    } catch (err) {
+      onToast?.('Error fetching users');
+      console.error(err);
+      return [];
+    }
+  }, [baseUrl, token, onToast]);
+
+  const fetchAllWorkspaces = useCallback(async () => {
+    try {
+      const res = await fetch(`${baseUrl}/admin_workspaces_get_all.php`, {
+        headers: {
+          Authorization: `Bearer ${token}`
+        }
+      });
+      const data = await res.json();
+      if (!data.success) throw new Error(data.message || 'Failed to fetch workspaces');
+      setWorkspaces(data.workspaces);
+      return data.workspaces;
+    } catch (err) {
+      onToast?.('Error fetching workspaces');
+      console.error(err);
+      return [];
+    }
+  }, [baseUrl, token, onToast]);
+
+  const createWorkspaceForUser = useCallback(async (ownerId, name) => {
+    try {
+      const res = await fetch(`${baseUrl}/admin_workspace_create.php`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${token}`
+        },
+        body: JSON.stringify({ owner_id: ownerId, name })
+      });
+      const data = await res.json();
+      if (!data.success) throw new Error(data.message || 'Failed to create workspace');
+      await fetchAllWorkspaces();
+      onToast?.('Workspace created');
+    } catch (err) {
+      onToast?.('Failed to create workspace');
+      console.error(err);
+    }
+  }, [baseUrl, token, fetchAllWorkspaces, onToast]);
+
+  const deleteWorkspace = useCallback(async (workspaceId) => {
+    try {
+      const res = await fetch(`${baseUrl}/admin_workspace_delete.php?id=${workspaceId}`, {
+        method: 'DELETE',
+        headers: {
+          Authorization: `Bearer ${token}`
+        }
+      });
+      const data = await res.json();
+      if (!data.success) throw new Error(data.message || 'Failed to delete workspace');
+      await fetchAllWorkspaces();
+      onToast?.('Workspace deleted');
+    } catch (err) {
+      onToast?.('Failed to delete workspace');
+      console.error(err);
+    }
+  }, [baseUrl, token, fetchAllWorkspaces, onToast]);
+
+  return {
+    users,
+    workspaces,
+    fetchUsers,
+    fetchAllWorkspaces,
+    createWorkspaceForUser,
+    deleteWorkspace
+  };
+}


### PR DESCRIPTION
## Summary
- add secure admin-only API endpoints to manage users and workspaces
- introduce useAdminApi hook and modal-based admin panel UI
- expose Admin Panel option in user menu when JWT marks user as admin

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: 312 problems (309 errors, 3 warnings))*

------
https://chatgpt.com/codex/tasks/task_b_689237e7bb208332b214b9ca87f6080f