### PR TITLE
Allow retrieving personas without workspace ID

### DIFF
--- a/api/personas_get.php
+++ b/api/personas_get.php
@@ -13,7 +13,7 @@ try {
             pc.collection_id
         FROM personas p
         LEFT JOIN persona_collections pc ON p.id = pc.persona_id
-        WHERE p.user_id = ? AND p.workspace_id = ?
+        WHERE p.user_id = ? AND (p.workspace_id = ? OR p.workspace_id IS NULL)
         ORDER BY p.created_at DESC
     ");
     $stmt->execute([$user_id, $workspace_id]);


### PR DESCRIPTION
## Summary
- fetch personas with null `workspace_id` alongside current workspace

## Testing
- `php api/migrate_workspace_ids.php` (fails: Connection refused)
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: 312 problems)


------
https://chatgpt.com/codex/tasks/task_b_68923e7d3e008332a072cae0a38cfbe9