### PR TITLE
Fix workspace fetch loop and clean API CORS

### DIFF
--- a/api/workspaces_get.php
+++ b/api/workspaces_get.php
@@ -1,14 +1,4 @@
 <?php
-header('Access-Control-Allow-Origin: http://localhost:5173');
-header('Access-Control-Allow-Credentials: true');
-header('Access-Control-Allow-Headers: Content-Type, Authorization');
-header('Access-Control-Allow-Methods: GET, POST, PUT, DELETE, OPTIONS');
-
-if ($_SERVER['REQUEST_METHOD'] === 'OPTIONS') {
-    http_response_code(200);
-    exit;
-}
-
 require 'cors.php';
 require 'db.php';
 require 'auth_check.php'; // levert $user_id

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -127,19 +127,21 @@ const {
 useEffect(() => {
   if (!token) return;
 
-  fetchWorkspaces().then(() => {
+  (async () => {
+    const fetched = await fetchWorkspaces();
     const storedWorkspaceId = localStorage.getItem('vault_activeWorkspaceId');
-    const validStoredId = storedWorkspaceId && workspaces.some(w => w.id === parseInt(storedWorkspaceId, 10));
+    const validStoredId =
+      storedWorkspaceId && fetched.some(w => w.id === parseInt(storedWorkspaceId, 10));
 
     if (validStoredId) {
       setActiveWorkspaceId(parseInt(storedWorkspaceId, 10));
-    } else if (workspaces.length > 0) {
-      const fallbackId = workspaces[0].id;
+    } else if (fetched.length > 0) {
+      const fallbackId = fetched[0].id;
       setActiveWorkspaceId(fallbackId);
       localStorage.setItem('vault_activeWorkspaceId', fallbackId);
     }
-  });
-}, [token, fetchWorkspaces, workspaces]);
+  })();
+}, [token, fetchWorkspaces]);
 
 
 
@@ -365,35 +367,40 @@ const handleUpdateTags = ({ action, targetTag, newTag, sourceTag }) => {
 />
 
 {workspaces.length > 0 && (
-  <div className="max-w-5xl mx-auto mb-2 flex justify-between items-center">
+  <div className="max-w-5xl mx-auto mb-2 mt-4 flex justify-between items-center">
     <div className="flex items-center space-x-2 text-sm">
       <label htmlFor="workspaceSelect" className="text-gray-700 dark:text-gray-300 font-medium">
         Workspace:
       </label>
-      <select
-        id="workspaceSelect"
-        className="px-2 py-1 rounded border bg-white dark:bg-gray-800 dark:text-white border-gray-300 dark:border-gray-600"
-        value={activeWorkspaceId || ''}
-        onChange={(e) => {
-          const newId = parseInt(e.target.value, 10);
-          setActiveWorkspaceId(newId);
-          localStorage.setItem('vault_activeWorkspaceId', newId);
-          setGlobalToastMessage('Switched workspace!');
-          fetchPersonas();
-          fetchPrompts();
-          fetchCollections();
-        }}
-      >
-        {workspaces.map((ws) => (
-          <option key={ws.id} value={ws.id}>
-            {ws.name}
-          </option>
-        ))}
-      </select>
+      <div className="relative">
+        <select
+          id="workspaceSelect"
+          className="appearance-none bg-white dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded-full px-4 py-1.5 pr-8 text-sm text-gray-700 dark:text-gray-200 shadow-sm focus:ring-2 focus:ring-blue-500 focus:border-blue-500 transition duration-200 ease-in-out hover:shadow-md cursor-pointer"
+          value={activeWorkspaceId || ''}
+          onChange={(e) => {
+            const newId = parseInt(e.target.value, 10);
+            setActiveWorkspaceId(newId);
+            localStorage.setItem('vault_activeWorkspaceId', newId);
+            setGlobalToastMessage('Switched workspace!');
+            fetchPersonas();
+            fetchPrompts();
+            fetchCollections();
+          }}
+        >
+          {workspaces.map((ws) => (
+            <option key={ws.id} value={ws.id}>
+              {ws.name}
+            </option>
+          ))}
+        </select>
+        <div className="pointer-events-none absolute inset-y-0 right-3 flex items-center text-gray-400 dark:text-gray-300">
+          ▼
+        </div>
+      </div>
     </div>
 
     <button
-      className="ml-4 px-3 py-1.5 bg-blue-600 text-white rounded text-sm hover:bg-blue-700 transition-all"
+      className="ml-4 mt-2 px-3 py-1.5 bg-blue-600 text-white rounded text-sm hover:bg-blue-700 transition-all"
       onClick={() => {
         const name = prompt('Geef een naam voor je nieuwe workspace:');
         if (name && name.trim().length > 1) {

--- a/src/hooks/useWorkspacesApi.js
+++ b/src/hooks/useWorkspacesApi.js
@@ -21,10 +21,12 @@ export function useWorkspacesApi(token, onToast) {
       if (!result.success) throw new Error(result.message || 'Failed to fetch workspaces');
 
       setWorkspaces(result.workspaces);
+      return result.workspaces;
     } catch (err) {
       setError(err.message);
       onToast?.('Error fetching workspaces');
       console.error(err);
+      return [];
     } finally {
       setLoading(false);
     }


### PR DESCRIPTION
## Summary
- simplify `workspaces_get.php` CORS handling
- ensure workspace fetching returns data for callers
- load workspaces once in `App` and set active workspace reliably
- style workspace selector like other dropdowns and give "Nieuwe Workspace" button top margin

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 312 problems)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68922c74573883328022fee0a56907bc