### PR TITLE
Persist collection renames

### DIFF
--- a/api/collections_update.php
+++ b/api/collections_update.php
@@ -1,0 +1,32 @@
+<?php
+header('Content-Type: application/json');
+include 'cors.php';
+require 'auth_check.php';
+require 'db.php';
+
+$data = json_decode(file_get_contents('php://input'), true);
+$id = $data['id'] ?? 0;
+$name = trim($data['name'] ?? '');
+
+if (!$id || empty($name)) {
+    http_response_code(400);
+    echo json_encode(['error' => 'Invalid id or name']);
+    exit;
+}
+
+try {
+    $stmt = $pdo->prepare("UPDATE collections SET name = ?, updated_at = CURRENT_TIMESTAMP WHERE id = ? AND user_id = ? AND workspace_id = ?");
+    $stmt->execute([$name, $id, $user_id, $workspace_id]);
+
+    if ($stmt->rowCount() === 0) {
+        http_response_code(404);
+        echo json_encode(['error' => 'Collection not found']);
+        exit;
+    }
+
+    echo json_encode(['success' => true]);
+} catch (PDOException $e) {
+    http_response_code(500);
+    echo json_encode(['error' => 'Database error: ' . $e->getMessage()]);
+}
+?>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -188,6 +188,7 @@ useEffect(() => {
   createCollection,
   deleteCollection,
   fetchCollections,
+  renameCollection,
 } = useCollectionsApi(token, setGlobalToastMessage, activeWorkspaceId);
   
 
@@ -653,12 +654,17 @@ token={token}
   onAddCollection={(name) => {
     createCollection(name);
   }}
-  onRenameCollection={(id, newName) => {
+  onRenameCollection={async (id, newName) => {
     const updated = collections.map((c) =>
       c.id === id ? { ...c, name: newName } : c
     );
     setCollections(updated);
-    setGlobalToastMessage(`Collectie hernoemd naar "${newName}"`);
+    const success = await renameCollection(id, newName);
+    if (success) {
+      setGlobalToastMessage(`Collectie hernoemd naar "${newName}"`);
+    } else {
+      setGlobalToastMessage('Error renaming collection');
+    }
   }}
   onDeleteCollection={(id) => {
     deleteCollection(id);

--- a/src/hooks/useCollectionsApi.js
+++ b/src/hooks/useCollectionsApi.js
@@ -91,6 +91,31 @@ export function useCollectionsApi(token, onShowToast, workspaceId) {
     }
   }, [token, fetchCollections, stableHandleError, workspaceId]);
 
+  const renameCollection = useCallback(async (id, name) => {
+    try {
+      const response = await fetch(`${BASE_URL}/collections_update.php`, {
+        method: 'PUT',
+        headers: {
+          'Content-Type': 'application/json',
+          'Authorization': `Bearer ${token}`,
+        },
+        body: JSON.stringify({ id, name, workspace_id: workspaceId }),
+      });
+      const data = await response.json();
+      if (data.success) {
+        await fetchCollections();
+      } else {
+        stableHandleError(new Error('API returned failure'), 'Failed to rename collection');
+      }
+      return data.success;
+    } catch (err) {
+      console.error('Failed to rename collection:', err);
+      setError(err);
+      stableHandleError(err, 'Failed to rename collection');
+      return false;
+    }
+  }, [token, fetchCollections, stableHandleError, workspaceId]);
+
   useEffect(() => {
     if (token && typeof token === 'string' && token.length > 100 && token.startsWith('eyJ')) {
       console.log('useCollectionsApi → Valid token → fetching collections');
@@ -108,5 +133,6 @@ export function useCollectionsApi(token, onShowToast, workspaceId) {
     fetchCollections,
     createCollection,
     deleteCollection,
+    renameCollection,
   };
 }


### PR DESCRIPTION
## Summary
- support updating collection names via new API endpoint
- wire renameCollection through useCollectionsApi and App

## Testing
- `npx eslint src && echo "Lint OK"`


------
https://chatgpt.com/codex/tasks/task_b_689247afbb3c833282b1d9a1707dcfce