### PR TITLE
feat: add admin user and global stats

### DIFF
--- a/api/admin_stats_global.php
+++ b/api/admin_stats_global.php
@@ -1,0 +1,32 @@
+<?php
+require 'cors.php';
+require 'db.php';
+require 'auth_check_admin.php';
+
+header('Content-Type: application/json');
+
+try {
+    $totalPersonas = $pdo->query("SELECT COUNT(*) FROM personas")->fetchColumn();
+    $totalPrompts = $pdo->query("SELECT COUNT(*) FROM prompts")->fetchColumn();
+    $avgPromptsPerPersona = $totalPersonas > 0 ? $totalPrompts / $totalPersonas : 0;
+
+    $workspaceStmt = $pdo->query("SELECT w.id, w.name, COUNT(p.id) AS prompt_count FROM workspaces w LEFT JOIN prompts p ON p.workspace_id = w.id GROUP BY w.id ORDER BY prompt_count DESC LIMIT 1");
+    $mostActive = $workspaceStmt->fetch(PDO::FETCH_ASSOC);
+
+    echo json_encode([
+        'success' => true,
+        'stats' => [
+            'total_personas' => (int)$totalPersonas,
+            'total_prompts' => (int)$totalPrompts,
+            'average_prompts_per_persona' => (float)$avgPromptsPerPersona,
+            'most_active_workspace' => $mostActive
+        ]
+    ]);
+} catch (PDOException $e) {
+    http_response_code(500);
+    echo json_encode([
+        'success' => false,
+        'message' => 'Database error: ' . $e->getMessage()
+    ]);
+}
+?>

--- a/api/admin_users_get.php
+++ b/api/admin_users_get.php
@@ -6,8 +6,31 @@ require 'auth_check_admin.php';
 header('Content-Type: application/json');
 
 try {
-    $stmt = $pdo->query("SELECT id, username, email FROM users ORDER BY username ASC");
+    $stmt = $pdo->query("SELECT id, username, email, is_admin FROM users ORDER BY username ASC");
     $users = $stmt->fetchAll(PDO::FETCH_ASSOC);
+
+    foreach ($users as &$user) {
+        $user_id = (int)$user['id'];
+
+        $personaCount = $pdo->prepare("SELECT COUNT(*) FROM personas WHERE user_id = ?");
+        $personaCount->execute([$user_id]);
+        $user['persona_count'] = (int)$personaCount->fetchColumn();
+
+        $promptCount = $pdo->prepare("SELECT COUNT(*) FROM prompts WHERE user_id = ?");
+        $promptCount->execute([$user_id]);
+        $user['prompt_count'] = (int)$promptCount->fetchColumn();
+
+        $collectionCount = $pdo->prepare("SELECT COUNT(*) FROM collections WHERE user_id = ?");
+        $collectionCount->execute([$user_id]);
+        $user['collection_count'] = (int)$collectionCount->fetchColumn();
+
+        $workspaceCount = $pdo->prepare("SELECT COUNT(*) FROM workspace_members WHERE user_id = ?");
+        $workspaceCount->execute([$user_id]);
+        $user['workspace_count'] = (int)$workspaceCount->fetchColumn();
+
+        $user['is_admin'] = (bool)$user['is_admin'];
+    }
+
     echo json_encode(['success' => true, 'users' => $users]);
 } catch (PDOException $e) {
     http_response_code(500);

--- a/src/components/AdminPanelModal.jsx
+++ b/src/components/AdminPanelModal.jsx
@@ -7,8 +7,10 @@ export default function AdminPanelModal({ isOpen, onClose, token, onToast }) {
   const {
     users,
     workspaces,
+    globalStats,
     fetchUsers,
     fetchAllWorkspaces,
+    fetchGlobalStats,
     createWorkspaceForUser,
     deleteWorkspace
   } = useAdminApi(token, onToast);
@@ -20,8 +22,9 @@ export default function AdminPanelModal({ isOpen, onClose, token, onToast }) {
     if (isOpen) {
       fetchUsers();
       fetchAllWorkspaces();
+      fetchGlobalStats();
     }
-  }, [isOpen, fetchUsers, fetchAllWorkspaces]);
+  }, [isOpen, fetchUsers, fetchAllWorkspaces, fetchGlobalStats]);
 
   if (!isOpen) return null;
 
@@ -48,6 +51,71 @@ export default function AdminPanelModal({ isOpen, onClose, token, onToast }) {
         </button>
 
         <h2 className="text-2xl font-bold text-gray-900 dark:text-white">Admin Panel</h2>
+
+        {globalStats && (
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+            <div className="p-4 rounded-lg bg-gray-100 dark:bg-gray-800">
+              <div className="text-sm text-gray-500">Total personas</div>
+              <div className="text-xl font-semibold">{globalStats.total_personas}</div>
+            </div>
+            <div className="p-4 rounded-lg bg-gray-100 dark:bg-gray-800">
+              <div className="text-sm text-gray-500">Total prompts</div>
+              <div className="text-xl font-semibold">{globalStats.total_prompts}</div>
+            </div>
+            <div className="p-4 rounded-lg bg-gray-100 dark:bg-gray-800">
+              <div className="text-sm text-gray-500">Avg. prompts per persona</div>
+              <div className="text-xl font-semibold">
+                {globalStats.average_prompts_per_persona.toFixed(2)}
+              </div>
+            </div>
+            {globalStats.most_active_workspace && (
+              <div className="p-4 rounded-lg bg-gray-100 dark:bg-gray-800">
+                <div className="text-sm text-gray-500">Most active workspace</div>
+                <div className="text-xl font-semibold">
+                  {globalStats.most_active_workspace.name}
+                </div>
+              </div>
+            )}
+          </div>
+        )}
+
+        {/* Users stats */}
+        <div className="border-t border-gray-200 dark:border-gray-700 pt-4">
+          <h3 className="text-lg font-semibold mb-2">User statistics</h3>
+          <div className="max-h-64 overflow-y-auto">
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="text-left text-gray-500">
+                  <th className="px-2 py-1">User</th>
+                  <th className="px-2 py-1">Personas</th>
+                  <th className="px-2 py-1">Prompts</th>
+                  <th className="px-2 py-1">Collections</th>
+                  <th className="px-2 py-1">Workspaces</th>
+                  <th className="px-2 py-1">Admin</th>
+                </tr>
+              </thead>
+              <tbody>
+                {users.map((u) => (
+                  <tr key={u.id} className="border-t border-gray-200 dark:border-gray-700">
+                    <td className="px-2 py-1">{u.username}</td>
+                    <td className="px-2 py-1">{u.persona_count}</td>
+                    <td className="px-2 py-1">{u.prompt_count}</td>
+                    <td className="px-2 py-1">{u.collection_count}</td>
+                    <td className="px-2 py-1">{u.workspace_count}</td>
+                    <td className="px-2 py-1">{u.is_admin ? 'Yes' : 'No'}</td>
+                  </tr>
+                ))}
+                {users.length === 0 && (
+                  <tr>
+                    <td className="px-2 py-1 text-gray-500" colSpan="6">
+                      No users found
+                    </td>
+                  </tr>
+                )}
+              </tbody>
+            </table>
+          </div>
+        </div>
 
         {/* Create workspace */}
         <div className="space-y-2">

--- a/src/hooks/useAdminApi.js
+++ b/src/hooks/useAdminApi.js
@@ -3,6 +3,7 @@ import { useCallback, useState } from 'react';
 export function useAdminApi(token, onToast) {
   const [users, setUsers] = useState([]);
   const [workspaces, setWorkspaces] = useState([]);
+  const [globalStats, setGlobalStats] = useState(null);
 
   const baseUrl = import.meta.env.VITE_API_BASE_URL;
 
@@ -80,11 +81,31 @@ export function useAdminApi(token, onToast) {
     }
   }, [baseUrl, token, fetchAllWorkspaces, onToast]);
 
+  const fetchGlobalStats = useCallback(async () => {
+    try {
+      const res = await fetch(`${baseUrl}/admin_stats_global.php`, {
+        headers: {
+          Authorization: `Bearer ${token}`
+        }
+      });
+      const data = await res.json();
+      if (!data.success) throw new Error(data.message || 'Failed to fetch stats');
+      setGlobalStats(data.stats);
+      return data.stats;
+    } catch (err) {
+      onToast?.('Error fetching stats');
+      console.error(err);
+      return null;
+    }
+  }, [baseUrl, token, onToast]);
+
   return {
     users,
     workspaces,
+    globalStats,
     fetchUsers,
     fetchAllWorkspaces,
+    fetchGlobalStats,
     createWorkspaceForUser,
     deleteWorkspace
   };


### PR DESCRIPTION
## Summary
- extend admin user endpoint with persona, prompt, collection, workspace counts and admin flag
- add global stats endpoint and UI integration
- show user and platform metrics in admin panel

## Testing
- `npm run lint`
- `php -l api/admin_users_get.php`
- `php -l api/admin_stats_global.php`


------
https://chatgpt.com/codex/tasks/task_b_68924c51fc088332859f696ab29e2a94