### PR TITLE
feat: track user sessions for admin stats

### DIFF
--- a/api/admin_users_get.php
+++ b/api/admin_users_get.php
@@ -28,6 +28,13 @@ try {
         $workspaceCount->execute([$user_id]);
         $user['workspace_count'] = (int)$workspaceCount->fetchColumn();
 
+        // Login frequency and session duration
+        $sessionStats = $pdo->prepare("SELECT COUNT(*) AS login_count, AVG(TIMESTAMPDIFF(MINUTE, login_time, IFNULL(logout_time, NOW()))) AS avg_minutes FROM user_sessions WHERE user_id = ?");
+        $sessionStats->execute([$user_id]);
+        $stats = $sessionStats->fetch(PDO::FETCH_ASSOC);
+        $user['login_count'] = (int)($stats['login_count'] ?? 0);
+        $user['avg_session_minutes'] = $stats['avg_minutes'] !== null ? (float)$stats['avg_minutes'] : 0;
+
         $user['is_admin'] = (bool)$user['is_admin'];
     }
 

--- a/api/auth_login.php
+++ b/api/auth_login.php
@@ -52,6 +52,10 @@ if (!$workspaceId) {
     exit;
 }
 
+// Log login time for user session tracking
+$sessionStmt = $pdo->prepare("INSERT INTO user_sessions (user_id, login_time) VALUES (?, NOW())");
+$sessionStmt->execute([$user['id']]);
+
 // ✅ JWT genereren (met admin-info)
 $token = generate_jwt([
     'user_id' => $user['id'],

--- a/api/auth_logout.php
+++ b/api/auth_logout.php
@@ -1,0 +1,19 @@
+<?php
+require 'cors.php';
+require 'db.php';
+require 'auth_check.php';
+
+header('Content-Type: application/json');
+
+try {
+    $stmt = $pdo->prepare("UPDATE user_sessions SET logout_time = NOW() WHERE user_id = ? AND logout_time IS NULL ORDER BY login_time DESC LIMIT 1");
+    $stmt->execute([$user_id]);
+    echo json_encode(['success' => true]);
+} catch (PDOException $e) {
+    http_response_code(500);
+    echo json_encode([
+        'success' => false,
+        'message' => 'Database error: ' . $e->getMessage()
+    ]);
+}
+?>

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -4,7 +4,7 @@ import reactHooks from 'eslint-plugin-react-hooks'
 import reactRefresh from 'eslint-plugin-react-refresh'
 
 export default [
-  { ignores: ['dist'] },
+  { ignores: ['dist', '.vite'] },
   {
     files: ['**/*.{js,jsx}'],
     languageOptions: {

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -270,9 +270,23 @@ useEffect(() => {
   }
   
   
- const handleLogout = () => {
-  localStorage.removeItem('token');
-  setToken(null);
+ const handleLogout = async () => {
+  try {
+    const baseUrl = import.meta.env.VITE_API_BASE_URL;
+    await fetch(`${baseUrl}/auth_logout.php`, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${token}`
+      }
+    });
+  } catch (err) {
+    console.error(err);
+  } finally {
+    localStorage.removeItem('vault_jwt_token');
+    setToken(null);
+    setUsername('');
+    setDecodedToken(null);
+  }
 };
   
 
@@ -687,12 +701,7 @@ token={token}
   favoriteCount={favoriteCount}
   promptsWithoutTagCount={promptsWithoutTagCount}
   tagsUsed={tagsUsed}
-  onLogout={() => {
-    localStorage.removeItem('vault_jwt_token');
-    setToken(null);
-    setUsername('');
-    setDecodedToken(null);
-  }}
+  onLogout={handleLogout}
   onClose={() => setIsProfileModalOpen(false)}
   onNewPrompt={() => {
     setSelectedTab('prompts');

--- a/src/components/AdminPanelModal.jsx
+++ b/src/components/AdminPanelModal.jsx
@@ -91,6 +91,8 @@ export default function AdminPanelModal({ isOpen, onClose, token, onToast }) {
                   <th className="px-2 py-1">Prompts</th>
                   <th className="px-2 py-1">Collections</th>
                   <th className="px-2 py-1">Workspaces</th>
+                  <th className="px-2 py-1">Logins</th>
+                  <th className="px-2 py-1">Avg session (min)</th>
                   <th className="px-2 py-1">Admin</th>
                 </tr>
               </thead>
@@ -102,12 +104,14 @@ export default function AdminPanelModal({ isOpen, onClose, token, onToast }) {
                     <td className="px-2 py-1">{u.prompt_count}</td>
                     <td className="px-2 py-1">{u.collection_count}</td>
                     <td className="px-2 py-1">{u.workspace_count}</td>
+                    <td className="px-2 py-1">{u.login_count}</td>
+                    <td className="px-2 py-1">{u.avg_session_minutes.toFixed(1)}</td>
                     <td className="px-2 py-1">{u.is_admin ? 'Yes' : 'No'}</td>
                   </tr>
                 ))}
                 {users.length === 0 && (
                   <tr>
-                    <td className="px-2 py-1 text-gray-500" colSpan="6">
+                    <td className="px-2 py-1 text-gray-500" colSpan="8">
                       No users found
                     </td>
                   </tr>


### PR DESCRIPTION
## Summary
- log login events and track logout to measure session duration
- expose login count and average session time in admin users endpoint
- display session stats in admin panel and wire frontend logout to API

## Testing
- `npm run lint`
- `php -l api/auth_login.php`
- `php -l api/auth_logout.php`
- `php -l api/admin_users_get.php`


------
https://chatgpt.com/codex/tasks/task_b_689267eb58a4833299d5bf3215f18059