### PR TITLE
feat: improve responsive layout

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -388,7 +388,7 @@ const handleUpdateTags = ({ action, targetTag, newTag, sourceTag }) => {
 />
 
 {workspaces.length > 0 && (
-  <div className="max-w-5xl mx-auto mb-2 mt-4 flex justify-between items-center">
+  <div className="max-w-screen-xl mx-auto px-2 sm:px-4 mb-2 mt-4 flex justify-between items-center">
     <div className="flex items-center space-x-2 text-sm">
       <label htmlFor="workspaceSelect" className="text-gray-700 dark:text-gray-300 font-medium">
         Workspace:
@@ -439,7 +439,7 @@ const handleUpdateTags = ({ action, targetTag, newTag, sourceTag }) => {
 
 
 
-      <div className="max-w-5xl mx-auto mb-4 mt-6">
+      <div className="max-w-screen-xl mx-auto px-2 sm:px-4 mb-4 mt-6">
         <FavoritesFilter
           showFavoritesOnly={showFavoritesOnly}
           onToggleFavorites={setShowFavoritesOnly}
@@ -447,7 +447,7 @@ const handleUpdateTags = ({ action, targetTag, newTag, sourceTag }) => {
         />
       </div>
 
-      <div className="max-w-5xl mx-auto mb-4 flex flex-wrap gap-2 items-center">
+      <div className="max-w-screen-xl mx-auto px-2 sm:px-4 mb-4 flex flex-wrap gap-2 items-center">
   <TagFilterDropdown
     tags={[...personas.map((p) => p.tags || []), ...prompts.map((p) => p.tags || [])]}
     activeTags={activeTags}
@@ -462,7 +462,7 @@ const handleUpdateTags = ({ action, targetTag, newTag, sourceTag }) => {
 </div>
 
 
-     <div className="max-w-5xl mx-auto mb-8 mt-4">
+     <div className="max-w-screen-xl mx-auto px-2 sm:px-4 mb-8 mt-4">
   <div className="flex flex-wrap justify-center gap-2 sm:gap-3">
     {[
       { id: 'personas', label: 'Personas' },
@@ -565,7 +565,7 @@ const handleUpdateTags = ({ action, targetTag, newTag, sourceTag }) => {
 
 ) : (
   // Normal Dashboards wrapper
-  <div className="max-w-5xl mx-auto mb-16">
+  <div className="max-w-screen-xl mx-auto px-2 sm:px-4 mb-16">
     {/* Persona Dashboard */}
     <div className={`${selectedTab === 'personas' ? 'block' : 'hidden'}`}>
       <div className="flex flex-wrap justify-between items-center gap-y-2 mb-4">

--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -28,7 +28,7 @@ export default function Footer({ username, personasCount, promptsCount, onOpenSe
 
   return (
     <footer className="mt-12 py-6 text-xs text-gray-500 dark:text-gray-400 w-full bg-transparent">
-      <div className="max-w-5xl mx-auto px-4 flex flex-wrap justify-between items-center">
+      <div className="max-w-screen-xl mx-auto px-2 sm:px-4 flex flex-wrap justify-between items-center">
         <div className="mb-2 sm:mb-0 space-y-1 text-sm">
           <div>
             Personas: <strong>{personasCount}</strong> | Prompts: <strong>{promptsCount}</strong>

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -76,7 +76,7 @@ export default function Header({
   return (
     <>
       <header className="sticky top-0 z-50 backdrop-blur-md bg-gray-100/70 dark:bg-gray-900/70 border-b border-gray-200 dark:border-gray-700 shadow-sm">
-        <div className="flex items-center justify-between max-w-5xl mx-auto px-4 h-16">
+        <div className="flex items-center justify-between max-w-screen-xl mx-auto px-2 sm:px-4 h-16">
           {/* Logo */}
           <div className="flex items-center space-x-3">
             <img src={logoLight} alt="Persona Vault Logo" className="h-12 w-auto block dark:hidden" />

--- a/src/components/PersonaDashboard.jsx
+++ b/src/components/PersonaDashboard.jsx
@@ -167,7 +167,7 @@ const { revisions, loading: loadingRevisions, fetchRevisions } = usePersonaRevis
   };
 
   return (
-    <div className="p-6">
+    <div className="p-4 sm:p-6">
       <div className="flex justify-end mb-6">
         <Button onClick={startCreate}>+ Add Persona</Button>
       </div>
@@ -178,23 +178,24 @@ const { revisions, loading: loadingRevisions, fetchRevisions } = usePersonaRevis
           <p className="text-sm">Try adjusting your search or filters.</p>
         </div>
       ) : (
-        filteredPersonas.slice(0, visibleCount).map((persona) => (
-  <PersonaCard
-    key={persona.id}
-    persona={persona}
-    collections={collections}
-    onToggleFavorite={toggleFavorite}
-    onDelete={async () => {
-      await deletePersona(persona.id);
-      await fetchPersonas();
-      onShowToast('Persona deleted.');
-    }}
-    onEdit={startEdit}
-    onShowToast={onShowToast}
-    onViewRevisions={() => openRevisionsModal(persona)}
-    
-  />
-))
+        <div className="grid gap-4 sm:gap-6 grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
+          {filteredPersonas.slice(0, visibleCount).map((persona) => (
+            <PersonaCard
+              key={persona.id}
+              persona={persona}
+              collections={collections}
+              onToggleFavorite={toggleFavorite}
+              onDelete={async () => {
+                await deletePersona(persona.id);
+                await fetchPersonas();
+                onShowToast('Persona deleted.');
+              }}
+              onEdit={startEdit}
+              onShowToast={onShowToast}
+              onViewRevisions={() => openRevisionsModal(persona)}
+            />
+          ))}
+        </div>
       )}
 
       {hasMore && (

--- a/src/components/PromptDashboard.jsx
+++ b/src/components/PromptDashboard.jsx
@@ -104,7 +104,7 @@ export default function PromptDashboard({
   };
 
   return (
-    <div className="p-6">
+    <div className="p-4 sm:p-6">
       <div className="flex justify-end mb-6">
         <Button variant="primary" onClick={startCreate}>
           + Add Prompt
@@ -117,21 +117,23 @@ export default function PromptDashboard({
           <p className="text-sm">Try adjusting your search or filters.</p>
         </div>
       ) : (
-        filteredPrompts.slice(0, visibleCount).map((prompt) => (
-          <PromptCard
-            key={prompt.id}
-            prompt={prompt}
-            onToggleFavorite={(id, currentFavorite) => toggleFavorite(id, currentFavorite)}
-            onDelete={async () => {
-              await deletePrompt(prompt.id);
-              await fetchPrompts();
-              onShowToast('Prompt deleted.');
-            }}
-            onEdit={startEdit}
-            onViewRevisions={() => openRevisionsModal(prompt)}
-            onShowToast={onShowToast}
-          />
-        ))
+        <div className="grid gap-4 sm:gap-6 grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
+          {filteredPrompts.slice(0, visibleCount).map((prompt) => (
+            <PromptCard
+              key={prompt.id}
+              prompt={prompt}
+              onToggleFavorite={(id, currentFavorite) => toggleFavorite(id, currentFavorite)}
+              onDelete={async () => {
+                await deletePrompt(prompt.id);
+                await fetchPrompts();
+                onShowToast('Prompt deleted.');
+              }}
+              onEdit={startEdit}
+              onViewRevisions={() => openRevisionsModal(prompt)}
+              onShowToast={onShowToast}
+            />
+          ))}
+        </div>
       )}
 
       {hasMore && (


### PR DESCRIPTION
## Summary
- broaden layout containers to `max-w-screen-xl` with responsive padding
- implement responsive grid and spacing for persona and prompt dashboards

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_68926f9211248332801a87d3f838cd5b