### PR TITLE
fix: enforce workspace scoping for personas

### DIFF
--- a/api/auth_check.php
+++ b/api/auth_check.php
@@ -22,4 +22,19 @@ if (!$decoded || !isset($decoded['user_id']) || !isset($decoded['workspace_id'])
 }
 
 $user_id = $decoded['user_id'];
-$workspace_id = $decoded['workspace_id'];
+$workspace_id = (int)$decoded['workspace_id'];
+
+if (isset($_GET['workspace_id'])) {
+    $requestedWorkspaceId = (int)$_GET['workspace_id'];
+    if ($requestedWorkspaceId !== $workspace_id) {
+        $stmt = $pdo->prepare('SELECT 1 FROM workspaces w LEFT JOIN workspace_members wm ON w.id = wm.workspace_id WHERE w.id = ? AND (w.owner_id = ? OR wm.user_id = ?)');
+        $stmt->execute([$requestedWorkspaceId, $user_id, $user_id]);
+        if ($stmt->fetchColumn()) {
+            $workspace_id = $requestedWorkspaceId;
+        } else {
+            http_response_code(403);
+            echo json_encode(['error' => 'No access to this workspace']);
+            exit;
+        }
+    }
+}

--- a/api/personas_get.php
+++ b/api/personas_get.php
@@ -13,7 +13,7 @@ try {
             pc.collection_id
         FROM personas p
         LEFT JOIN persona_collections pc ON p.id = pc.persona_id
-        WHERE p.user_id = ? AND (p.workspace_id = ? OR p.workspace_id IS NULL)
+        WHERE p.user_id = ? AND p.workspace_id = ?
         ORDER BY p.created_at DESC
     ");
     $stmt->execute([$user_id, $workspace_id]);

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -133,16 +133,18 @@ useEffect(() => {
 
   (async () => {
     const fetched = await fetchWorkspaces();
-    const storedWorkspaceId = localStorage.getItem('vault_activeWorkspaceId');
+    const storedWorkspaceIdStr = localStorage.getItem('vault_activeWorkspaceId');
+    const storedWorkspaceId =
+      storedWorkspaceIdStr ? parseInt(storedWorkspaceIdStr, 10) : null;
     const validStoredId =
-      storedWorkspaceId && fetched.some(w => w.id === parseInt(storedWorkspaceId, 10));
+      storedWorkspaceId && fetched.some((w) => Number(w.id) === storedWorkspaceId);
 
     if (validStoredId) {
-      setActiveWorkspaceId(parseInt(storedWorkspaceId, 10));
+      setActiveWorkspaceId(storedWorkspaceId);
     } else if (fetched.length > 0) {
-      const fallbackId = fetched[0].id;
+      const fallbackId = Number(fetched[0].id);
       setActiveWorkspaceId(fallbackId);
-      localStorage.setItem('vault_activeWorkspaceId', fallbackId);
+      localStorage.setItem('vault_activeWorkspaceId', String(fallbackId));
     }
   })();
 }, [token, fetchWorkspaces]);
@@ -402,7 +404,7 @@ const handleUpdateTags = ({ action, targetTag, newTag, sourceTag }) => {
           onChange={(e) => {
             const newId = parseInt(e.target.value, 10);
             setActiveWorkspaceId(newId);
-            localStorage.setItem('vault_activeWorkspaceId', newId);
+            localStorage.setItem('vault_activeWorkspaceId', String(newId));
             setGlobalToastMessage('Switched workspace!');
             fetchPersonas();
             fetchPrompts();


### PR DESCRIPTION
## Summary
- allow API requests to override workspace via query parameter with membership checks
- limit persona list to entries inside active workspace
- restore the user's last selected workspace on reload by validating and storing workspace IDs consistently

## Testing
- `npm run lint`
- `php -l api/auth_check.php`
- `php -l api/personas_get.php`


------
https://chatgpt.com/codex/tasks/task_b_68927d077ed88332a2445144183390c8