### PR TITLE
feat: redesign auth pages with logo and modern layout

### DIFF
--- a/src/components/AuthLayout.jsx
+++ b/src/components/AuthLayout.jsx
@@ -1,35 +1,51 @@
 // src/components/AuthLayout.jsx
 export default function AuthLayout({ children, activeTab, onTabChange }) {
   return (
-    <div className="flex flex-col min-h-screen justify-center items-center bg-gradient-to-b from-gray-100 via-gray-50 to-white dark:from-gray-900 dark:via-gray-800 dark:to-gray-900 text-gray-900 dark:text-white px-4">
-
-      <h1 className="text-4xl font-bold mb-6">Persona Vault</h1>
-
-      <div className="flex space-x-4 mb-8">
-        <button
-          onClick={() => onTabChange('login')}
-          className={`px-5 py-2 rounded-full text-sm font-medium transition-all duration-200 ${
-            activeTab === 'login'
-              ? 'bg-blue-600 text-white scale-105 shadow-md'
-              : 'bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-300 hover:bg-blue-200 dark:hover:bg-blue-800'
-          }`}
-        >
-          Login
-        </button>
-
-        <button
-          onClick={() => onTabChange('register')}
-          className={`px-5 py-2 rounded-full text-sm font-medium transition-all duration-200 ${
-            activeTab === 'register'
-              ? 'bg-blue-600 text-white scale-105 shadow-md'
-              : 'bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-300 hover:bg-blue-200 dark:hover:bg-blue-800'
-          }`}
-        >
-          Register
-        </button>
+    <div className="min-h-screen grid md:grid-cols-2">
+      {/* Left promotional side */}
+      <div className="hidden md:flex flex-col justify-between p-12 bg-gradient-to-br from-indigo-600 via-purple-600 to-pink-500 text-white">
+        <div>
+          <img src="/logo-light.svg" alt="Persona Vault" className="h-10 mb-8" />
+          <h2 className="text-4xl font-bold mb-4">Welkom bij Persona Vault</h2>
+          <p className="text-lg opacity-90">Organiseer je AI-persona's en prompts op één plek.</p>
+        </div>
+        <p className="text-sm opacity-75">&copy; {new Date().getFullYear()} Persona Vault</p>
       </div>
 
-      <div className="w-full max-w-md">{children}</div>
+      {/* Auth card */}
+      <div className="flex flex-col justify-center items-center p-6 bg-gray-50 dark:bg-gray-900">
+        <div className="w-full max-w-md bg-white dark:bg-gray-800 rounded-2xl shadow-lg p-8">
+          <div className="mb-8 flex justify-center">
+            <img src="/logo-light.svg" alt="Persona Vault" className="h-10 dark:hidden" />
+            <img src="/logo-dark.svg" alt="Persona Vault" className="h-10 hidden dark:block" />
+          </div>
+
+          <div className="mb-8 flex rounded-full overflow-hidden bg-gray-100 dark:bg-gray-700">
+            <button
+              onClick={() => onTabChange('login')}
+              className={`w-1/2 py-2 text-sm font-medium transition-colors ${
+                activeTab === 'login'
+                  ? 'bg-white dark:bg-gray-800 text-blue-600 dark:text-blue-400 shadow'
+                  : 'text-gray-600 dark:text-gray-300'
+              }`}
+            >
+              Login
+            </button>
+            <button
+              onClick={() => onTabChange('register')}
+              className={`w-1/2 py-2 text-sm font-medium transition-colors ${
+                activeTab === 'register'
+                  ? 'bg-white dark:bg-gray-800 text-blue-600 dark:text-blue-400 shadow'
+                  : 'text-gray-600 dark:text-gray-300'
+              }`}
+            >
+              Register
+            </button>
+          </div>
+
+          {children}
+        </div>
+      </div>
     </div>
   );
 }

--- a/src/components/Input.jsx
+++ b/src/components/Input.jsx
@@ -23,7 +23,7 @@ const Input = forwardRef(function Input(
         onChange={onChange}
         placeholder={placeholder}
         required={required}
-        className={`p-2 border rounded focus:outline-none focus:ring-2 focus:ring-blue-500 transition ${className}`}
+        className={`p-3 border border-gray-300 rounded-lg bg-gray-50 focus:outline-none focus:ring-2 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-700 transition ${className}`}
         {...props}
       />
     </div>


### PR DESCRIPTION
## Summary
- revamp login and registration layout with two-column design and light/dark logos
- enhance form inputs for consistent light and dark mode styling

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_6894ec447c7c833289f24a0e2852a0d8