### PR TITLE
feat: make sidebar responsive and update styling

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -73,6 +73,17 @@ function App() {
   return localStorage.getItem('vault_setting_compactMode') === 'true';
 });
 
+  const [isSidebarOpen, setIsSidebarOpen] = useState(false);
+
+  useEffect(() => {
+    const updateSidebar = () => {
+      setIsSidebarOpen(window.innerWidth >= 640);
+    };
+    updateSidebar();
+    window.addEventListener('resize', updateSidebar);
+    return () => window.removeEventListener('resize', updateSidebar);
+  }, []);
+
 useEffect(() => {
   const token = localStorage.getItem('vault_jwt_token');
   const baseUrl = import.meta.env.VITE_API_BASE_URL;
@@ -374,8 +385,13 @@ const handleUpdateTags = ({ action, targetTag, newTag, sourceTag }) => {
 
 
   return (
-      <main className="min-h-screen flex bg-gradient-to-br from-gray-50 to-gray-100 dark:from-gray-900 dark:to-gray-800 text-gray-900 dark:text-white transition-colors duration-500">
-        <Sidebar selectedTab={selectedTab} setSelectedTab={setSelectedTab} />
+      <main className="min-h-screen flex bg-gradient-to-br from-white via-blue-50 to-purple-100 dark:from-gray-900 dark:via-gray-800 dark:to-gray-900 text-gray-900 dark:text-white transition-colors duration-500">
+        <Sidebar
+          selectedTab={selectedTab}
+          setSelectedTab={setSelectedTab}
+          isOpen={isSidebarOpen}
+          setIsOpen={setIsSidebarOpen}
+        />
         <div className="flex-1 px-2 sm:px-4 pb-16 sm:pb-0">
 
        {globalToastMessage && (
@@ -385,24 +401,24 @@ const handleUpdateTags = ({ action, targetTag, newTag, sourceTag }) => {
         )}
 
       <Header
-  personas={personas}
-  setPersonas={setPersonas}  
-  prompts={prompts}
-  setPrompts={setPrompts}
-  searchTerm={searchTerm}
-  setSearchTerm={setSearchTerm}
-  username={username}
-  onLogout={handleLogout}
-  onOpenProfile={() => setIsProfileModalOpen(true)}
-  createPersona={createPersona} // ✅ toevoegen
-  createPrompt={createPrompt}   // ✅ toevoegen
-    deletePersona={deletePersona}    // ✅ toevoegen
-    deletePrompt={deletePrompt}
-    handleUpdateTags={handleUpdateTags}
-    isAdmin={isAdmin}
-    onOpenAdminPanel={() => setIsAdminPanelOpen(true)}
-
-/>
+        personas={personas}
+        setPersonas={setPersonas}
+        prompts={prompts}
+        setPrompts={setPrompts}
+        searchTerm={searchTerm}
+        setSearchTerm={setSearchTerm}
+        username={username}
+        onLogout={handleLogout}
+        onOpenProfile={() => setIsProfileModalOpen(true)}
+        createPersona={createPersona} // ✅ toevoegen
+        createPrompt={createPrompt}   // ✅ toevoegen
+        deletePersona={deletePersona}    // ✅ toevoegen
+        deletePrompt={deletePrompt}
+        handleUpdateTags={handleUpdateTags}
+        isAdmin={isAdmin}
+        onOpenAdminPanel={() => setIsAdminPanelOpen(true)}
+        onToggleSidebar={() => setIsSidebarOpen((prev) => !prev)}
+      />
 
 {workspaces.length > 0 && (
   <div className="max-w-screen-xl mx-auto px-2 sm:px-4 mb-2 mt-4 flex justify-between items-center">

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -4,7 +4,7 @@ import DarkModeSwitch from './DarkModeSwitch';
 import AboutModal from './AboutModal';
 import SearchBar from './SearchBar';
 import { HiDotsVertical } from 'react-icons/hi';
-import { FiUpload, FiDownload, FiInfo, FiSettings, FiLogOut, FiUser, FiShield } from 'react-icons/fi';
+import { FiUpload, FiDownload, FiInfo, FiSettings, FiLogOut, FiUser, FiShield, FiMenu } from 'react-icons/fi';
 import TagManagerModal from './TagManagerModal';
 import logoLight from '/logo-light.svg';
 import logoDark from '/logo-dark.svg';
@@ -26,7 +26,8 @@ export default function Header({
   handleUpdateTags,
   onLogout,
   isAdmin,
-  onOpenAdminPanel
+  onOpenAdminPanel,
+  onToggleSidebar
 }) {
   const [isAboutOpen, setIsAboutOpen] = useState(false);
   const [mergeModalOpen, setMergeModalOpen] = useState(false);
@@ -79,6 +80,13 @@ export default function Header({
         <div className="flex items-center justify-between max-w-screen-xl mx-auto px-2 sm:px-4 h-16">
           {/* Logo */}
           <div className="flex items-center space-x-3">
+            <button
+              type="button"
+              onClick={onToggleSidebar}
+              className="md:hidden p-2 rounded-md text-gray-700 dark:text-gray-200 focus:outline-none"
+            >
+              <FiMenu className="w-6 h-6" />
+            </button>
             <img src={logoLight} alt="Persona Vault Logo" className="h-12 w-auto block dark:hidden" />
             <img src={logoDark} alt="Persona Vault Logo" className="h-12 w-auto hidden dark:block" />
           </div>

--- a/src/components/Sidebar.jsx
+++ b/src/components/Sidebar.jsx
@@ -1,16 +1,14 @@
 // src/components/Sidebar.jsx
 
-import React, { useState } from 'react';
+import React from 'react';
 import {
   FiUsers,
   FiFileText,
   FiFolder,
   FiChevronLeft,
-  FiChevronRight,
 } from 'react-icons/fi';
 
-export default function Sidebar({ selectedTab, setSelectedTab }) {
-  const [collapsed, setCollapsed] = useState(false);
+export default function Sidebar({ selectedTab, setSelectedTab, isOpen, setIsOpen }) {
 
   const navItems = [
     { id: 'personas', icon: FiUsers, label: 'Personas' },
@@ -21,21 +19,21 @@ export default function Sidebar({ selectedTab, setSelectedTab }) {
   return (
     <aside
       className={`
-        fixed top-0 left-0 h-full
+        fixed top-0 left-0 h-full w-20
         bg-white/70 dark:bg-gray-900/70
         backdrop-blur-md
         border-r border-gray-200 dark:border-gray-700
         py-6 space-y-6
-        
+
         transform transition-transform duration-300 ease-in-out
-        ${collapsed ? '-translate-x-full' : 'translate-x-0'}
+        ${isOpen ? 'translate-x-0' : '-translate-x-full'}
 
         z-20
       `}
     >
       {/* Navigatieknoppen */}
       <div className="flex flex-col items-center space-y-6">
-        {navItems.map(({ id, icon: Icon, label }) => {
+        {navItems.map(({ id, icon, label }) => {
           const active = selectedTab === id;
           return (
             <button
@@ -51,29 +49,27 @@ export default function Sidebar({ selectedTab, setSelectedTab }) {
                 }
               `}
             >
-              <Icon className="w-6 h-6" />
+              {React.createElement(icon, { className: 'w-6 h-6' })}
             </button>
           );
         })}
       </div>
 
-      {/* Collapse/Expand knop */}
-      <button
-        type="button"
-        onClick={() => setCollapsed(!collapsed)}
-        className="
-          absolute top-4 right-[-0.75rem]
-          p-1 bg-white dark:bg-gray-800
-          rounded-full shadow-md
-          focus:outline-none
-        "
-      >
-        {collapsed ? (
-          <FiChevronRight className="w-5 h-5 text-gray-600 dark:text-gray-300" />
-        ) : (
+      {/* Collapse knop */}
+      {isOpen && (
+        <button
+          type="button"
+          onClick={() => setIsOpen(false)}
+          className="
+            absolute top-4 right-[-0.75rem]
+            p-1 bg-white dark:bg-gray-800
+            rounded-full shadow-md
+            focus:outline-none
+          "
+        >
           <FiChevronLeft className="w-5 h-5 text-gray-600 dark:text-gray-300" />
-        )}
-      </button>
+        </button>
+      )}
     </aside>
   );
 }


### PR DESCRIPTION
## Summary
- hide sidebar on small screens and toggle via menu button
- allow collapsing sidebar
- refresh app background with modern gradient

## Testing
- `npm run lint`
- `npm run dev`

------
https://chatgpt.com/codex/tasks/task_b_6894f84d0d388332b25c620df9b66be9