### PR TITLE
feat: improve mobile responsiveness

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -32,6 +32,7 @@ import { testTokenValid } from './utils/tokenChecker';
 import { useWorkspacesApi } from './hooks/useWorkspacesApi';
 import { FiUsers, FiFileText, FiFolder } from 'react-icons/fi';
 import Sidebar from './components/Sidebar';
+import SearchBar from './components/SearchBar';
 
 function App() {
   const [searchTerm, setSearchTerm] = useState('');
@@ -419,6 +420,10 @@ const handleUpdateTags = ({ action, targetTag, newTag, sourceTag }) => {
         onOpenAdminPanel={() => setIsAdminPanelOpen(true)}
         onToggleSidebar={() => setIsSidebarOpen((prev) => !prev)}
       />
+
+      <div className="px-2 sm:px-4 mt-2 sm:hidden">
+        <SearchBar value={searchTerm} onChange={setSearchTerm} placeholder="Search..." />
+      </div>
 
 {workspaces.length > 0 && (
   <div className="max-w-screen-xl mx-auto px-2 sm:px-4 mb-2 mt-4 flex justify-between items-center">

--- a/src/components/AuthLayout.jsx
+++ b/src/components/AuthLayout.jsx
@@ -3,7 +3,7 @@ import darkLogo from '/logo-dark.svg';
 
 export default function AuthLayout({ children, activeTab, onTabChange }) {
   return (
-    <div className="min-h-screen grid md:grid-cols-2">
+    <div className="min-h-screen flex flex-col md:grid md:grid-cols-2">
 
       {/* —— Linkerkant: promo verticaal gecentreerd —— */}
       <div className="hidden md:flex flex-col p-12
@@ -26,10 +26,8 @@ export default function AuthLayout({ children, activeTab, onTabChange }) {
       </div>
 
       {/* —— Rechterkant: auth card —— */}
-      <div className="flex flex-col justify-center items-center
-                      p-6 bg-gray-50 dark:bg-gray-900">
-        <div className="w-full max-w-md bg-white dark:bg-gray-800
-                        rounded-3xl shadow-2xl p-10">
+      <div className="flex flex-col justify-center items-center p-4 sm:p-6 bg-gray-50 dark:bg-gray-900">
+        <div className="w-full max-w-sm sm:max-w-md bg-white dark:bg-gray-800 rounded-3xl shadow-2xl p-6 sm:p-10">
           {/* Logo + tabs + children blijven ongewijzigd */}
           <div className="mb-8 flex justify-center">
             <img src={lightLogo} alt="Persona Vault" className="h-10 dark:hidden" />

--- a/src/components/Sidebar.jsx
+++ b/src/components/Sidebar.jsx
@@ -19,9 +19,16 @@ export default function Sidebar({ selectedTab, setSelectedTab, isOpen, setIsOpen
   return (
 
     <>
+      {isOpen && (
+        <div
+          className="fixed inset-0 bg-black/40 z-10 sm:hidden"
+          onClick={() => setIsOpen(false)}
+        />
+      )}
+
       <aside
         className={`
-          fixed top-16 left-0 h-[calc(100vh-4rem)] w-20
+          fixed top-16 left-0 h-[calc(100vh-4rem)] w-64 sm:w-20
           bg-white/70 dark:bg-gray-900/70
           backdrop-blur-md
           border-r border-gray-200 dark:border-gray-700


### PR DESCRIPTION
## Summary
- make auth layout adapt padding and width on small screens
- add mobile overlay and wider width for sidebar
- expose search bar for small screens

## Testing
- `npm run lint`
- `npm run dev`

------
https://chatgpt.com/codex/tasks/task_b_68950cfb1c4c8332b1a52666a057e6e3