### PR TITLE
feat: improve mobile responsiveness

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, viewport-fit=cover" />
     <meta name="theme-color" content="#2563eb" />
     <meta name="description" content="Persona Vault — Beheer je Persona's en Prompts in een moderne vault webapp." />
 
@@ -13,6 +13,10 @@
 
     <!-- Manifest -->
     <link rel="manifest" href="/vault/manifest.webmanifest" />
+    <meta name="mobile-web-app-capable" content="yes" />
+    <meta name="apple-mobile-web-app-capable" content="yes" />
+    <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
+    <link rel="apple-touch-icon" href="/logo-192.png" />
 
     <!-- Social sharing -->
     <meta property="og:title" content="Persona Vault" />

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,0 +1,26 @@
+const CACHE_NAME = 'persona-vault-v1';
+const URLS_TO_CACHE = [
+  '/',
+  '/index.html',
+  '/manifest.webmanifest',
+];
+
+self.addEventListener('install', (event) => {
+  event.waitUntil(
+    caches.open(CACHE_NAME).then((cache) => cache.addAll(URLS_TO_CACHE))
+  );
+});
+
+self.addEventListener('activate', (event) => {
+  event.waitUntil(
+    caches.keys().then((keys) =>
+      Promise.all(keys.filter((key) => key !== CACHE_NAME).map((key) => caches.delete(key)))
+    )
+  );
+});
+
+self.addEventListener('fetch', (event) => {
+  event.respondWith(
+    caches.match(event.request).then((response) => response || fetch(event.request))
+  );
+});

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -32,6 +32,7 @@ import { testTokenValid } from './utils/tokenChecker';
 import { useWorkspacesApi } from './hooks/useWorkspacesApi';
 import { FiUsers, FiFileText, FiFolder } from 'react-icons/fi';
 import Sidebar from './components/Sidebar';
+import SearchBar from './components/SearchBar';
 
 function App() {
   const [searchTerm, setSearchTerm] = useState('');
@@ -419,6 +420,10 @@ const handleUpdateTags = ({ action, targetTag, newTag, sourceTag }) => {
         onOpenAdminPanel={() => setIsAdminPanelOpen(true)}
         onToggleSidebar={() => setIsSidebarOpen((prev) => !prev)}
       />
+
+      <div className="px-2 sm:px-4 mt-2 sm:hidden">
+        <SearchBar value={searchTerm} onChange={setSearchTerm} placeholder="Search..." />
+      </div>
 
 {workspaces.length > 0 && (
   <div className="max-w-screen-xl mx-auto px-2 sm:px-4 mb-2 mt-4 flex justify-between items-center">

--- a/src/components/AuthLayout.jsx
+++ b/src/components/AuthLayout.jsx
@@ -3,7 +3,7 @@ import darkLogo from '/logo-dark.svg';
 
 export default function AuthLayout({ children, activeTab, onTabChange }) {
   return (
-    <div className="min-h-screen grid md:grid-cols-2">
+    <div className="min-h-screen flex flex-col md:grid md:grid-cols-2">
 
       {/* —— Linkerkant: promo verticaal gecentreerd —— */}
       <div className="hidden md:flex flex-col p-12
@@ -26,10 +26,8 @@ export default function AuthLayout({ children, activeTab, onTabChange }) {
       </div>
 
       {/* —— Rechterkant: auth card —— */}
-      <div className="flex flex-col justify-center items-center
-                      p-6 bg-gray-50 dark:bg-gray-900">
-        <div className="w-full max-w-md bg-white dark:bg-gray-800
-                        rounded-3xl shadow-2xl p-10">
+      <div className="flex flex-col justify-center items-center p-4 sm:p-6 bg-gray-50 dark:bg-gray-900">
+        <div className="w-full max-w-sm sm:max-w-md bg-white dark:bg-gray-800 rounded-3xl shadow-2xl p-6 sm:p-10">
           {/* Logo + tabs + children blijven ongewijzigd */}
           <div className="mb-8 flex justify-center">
             <img src={lightLogo} alt="Persona Vault" className="h-10 dark:hidden" />

--- a/src/components/ScrollToTopButton.jsx
+++ b/src/components/ScrollToTopButton.jsx
@@ -29,9 +29,9 @@ export default function ScrollToTopButton() {
   return (
     <button
       onClick={scrollToTop}
-      className={`fixed bottom-6 right-6 z-40 p-3 rounded-full shadow-lg transition-all duration-300 ${
+      className={`fixed right-6 z-[60] p-3 rounded-full shadow-lg transition-all duration-300 ${
         isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-4 pointer-events-none'
-      } bg-blue-600 text-white hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-400 dark:bg-blue-700 dark:hover:bg-blue-600 dark:focus:ring-blue-500`}
+      } bg-blue-600 text-white hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-400 dark:bg-blue-700 dark:hover:bg-blue-600 dark:focus:ring-blue-500 bottom-20 sm:bottom-6`}
       aria-label="Scroll to top"
     >
       <FiArrowUp className="w-5 h-5" />

--- a/src/components/Sidebar.jsx
+++ b/src/components/Sidebar.jsx
@@ -19,9 +19,16 @@ export default function Sidebar({ selectedTab, setSelectedTab, isOpen, setIsOpen
   return (
 
     <>
+      {isOpen && (
+        <div
+          className="fixed inset-0 bg-black/40 z-10 sm:hidden"
+          onClick={() => setIsOpen(false)}
+        />
+      )}
+
       <aside
         className={`
-          fixed top-16 left-0 h-[calc(100vh-4rem)] w-20
+          fixed top-16 left-0 h-[calc(100vh-4rem)] w-64 sm:w-20
           bg-white/70 dark:bg-gray-900/70
           backdrop-blur-md
           border-r border-gray-200 dark:border-gray-700

--- a/src/index.css
+++ b/src/index.css
@@ -14,6 +14,12 @@ body {
   background-color: #f3f4f6; /* light mode → gray-100 */
 }
 
+html,
+body {
+  max-width: 100%;
+  overflow-x: hidden;
+}
+
 @media (prefers-color-scheme: dark) {
   body {
     background-color: #111827;

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -15,3 +15,11 @@ ReactDOM.createRoot(document.getElementById('root')).render(
     </BrowserRouter>
   </React.StrictMode>
 );
+
+if ('serviceWorker' in navigator) {
+  window.addEventListener('load', () => {
+    navigator.serviceWorker
+      .register(`${import.meta.env.BASE_URL}sw.js`)
+      .catch((err) => console.error('Service worker registration failed:', err));
+  });
+}


### PR DESCRIPTION
## Summary
- add PWA meta tags and service worker for offline support
- prevent horizontal overflow and adjust viewport on mobile
- move scroll-to-top button above bottom nav on small screens

## Testing
- `npm run lint`
- `npm run dev`


------
https://chatgpt.com/codex/tasks/task_b_68950cfb1c4c8332b1a52666a057e6e3