### PR TITLE
feat: add onboarding checklist and tooltip

### DIFF
--- a/src/components/OnboardingChecklist.jsx
+++ b/src/components/OnboardingChecklist.jsx
@@ -1,0 +1,50 @@
+import { useState, useEffect } from 'react';
+
+const defaultTasks = [
+  { key: 'completedProfile', label: 'Complete your profile' },
+  { key: 'createdPersona', label: 'Create your first persona' },
+  { key: 'createdPrompt', label: 'Create your first prompt' }
+];
+
+export default function OnboardingChecklist() {
+  const [tasks, setTasks] = useState(defaultTasks);
+
+  useEffect(() => {
+    setTasks(prev =>
+      prev.map(t => ({ ...t, done: localStorage.getItem(`vault_onboard_${t.key}`) === '1' }))
+    );
+  }, []);
+
+  const markDone = (key) => {
+    localStorage.setItem(`vault_onboard_${key}`, '1');
+    setTasks(prev => prev.map(t => t.key === key ? { ...t, done: true } : t));
+  };
+
+  const progress = Math.round((tasks.filter(t => t.done).length / tasks.length) * 100);
+
+  if (progress === 100) return null;
+
+  return (
+    <div className="mb-6 p-4 border rounded-lg bg-white dark:bg-gray-800">
+      <p className="mb-2 font-semibold">Getting started</p>
+      <div className="h-2 bg-gray-200 rounded">
+        <div className="h-2 bg-blue-500 rounded" style={{ width: `${progress}%` }}></div>
+      </div>
+      <ul className="mt-4 space-y-2">
+        {tasks.map(task => (
+          <li key={task.key} className="flex items-center justify-between">
+            <span className={task.done ? 'line-through text-gray-400' : ''}>{task.label}</span>
+            {!task.done && (
+              <button
+                className="text-xs text-blue-600 hover:underline"
+                onClick={() => markDone(task.key)}
+              >
+                Mark done
+              </button>
+            )}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/src/components/PromptDashboard.jsx
+++ b/src/components/PromptDashboard.jsx
@@ -3,6 +3,8 @@ import PromptForm from './PromptForm';
 import PromptCard from './PromptCard';
 import Button from './Button';
 import RevisionsModal from './RevisionsModal'; // 👈 nieuwe component
+import Tooltip from './Tooltip';
+import OnboardingChecklist from './OnboardingChecklist';
 import { useState, useEffect, useRef } from 'react';
 import { usePromptRevisionsApi } from '../hooks/usePromptRevisionsApi';
 
@@ -105,16 +107,21 @@ export default function PromptDashboard({
 
   return (
     <div className="p-4 sm:p-6">
+      <OnboardingChecklist />
       <div className="flex justify-end mb-6">
-        <Button variant="primary" onClick={startCreate}>
-          + Add Prompt
-        </Button>
+        <Tooltip text="Create a new prompt">
+          <Button variant="primary" onClick={startCreate}>
+            + Add Prompt
+          </Button>
+        </Tooltip>
       </div>
 
       {filteredPrompts.length === 0 ? (
         <div className="text-center py-8 text-gray-500 dark:text-gray-400">
-          <p className="text-lg mb-2">No prompts found.</p>
-          <p className="text-sm">Try adjusting your search or filters.</p>
+          <p className="text-lg mb-4">No prompts yet</p>
+          <Button variant="primary" onClick={startCreate}>
+            Create your first prompt
+          </Button>
         </div>
       ) : (
         <div className="grid gap-4 sm:gap-6 grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">

--- a/src/components/Tooltip.jsx
+++ b/src/components/Tooltip.jsx
@@ -1,0 +1,22 @@
+import { useState } from 'react';
+
+export default function Tooltip({ children, text }) {
+  const [visible, setVisible] = useState(false);
+
+  return (
+    <div
+      className="relative inline-block"
+      onMouseEnter={() => setVisible(true)}
+      onMouseLeave={() => setVisible(false)}
+      onFocus={() => setVisible(true)}
+      onBlur={() => setVisible(false)}
+    >
+      {children}
+      {visible && (
+        <div className="absolute z-10 w-max max-w-xs p-2 text-sm text-white bg-gray-900 rounded shadow-lg -translate-x-1/2 left-1/2 mt-2">
+          {text}
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add reusable Tooltip component for contextual hints
- add localStorage-backed OnboardingChecklist component
- enhance PromptDashboard with onboarding checklist, tooltip, and empty-state quick action

## Testing
- `npm run lint`
- `npm run dev`

------
https://chatgpt.com/codex/tasks/task_b_689539eb05ac8332ae0a9091e947086d