### PR TITLE
fix: restore revision history and modernize modal

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -679,6 +679,7 @@ isModalOpen={isPersonaModalOpen}
 setIsModalOpen={setIsPersonaModalOpen}
 setEditingPersona={setEditingPersona}
 token={token}
+workspaceId={activeWorkspaceId}
 
       />
     </div>
@@ -719,6 +720,7 @@ token={token}
         sortOption={promptSortOption}
         setSortOption={setPromptSortOption}
         compactMode={compactMode}
+        workspaceId={activeWorkspaceId}
       />
     </div>
 

--- a/src/components/PersonaDashboard.jsx
+++ b/src/components/PersonaDashboard.jsx
@@ -20,7 +20,8 @@ export default function PersonaDashboard({
   onShowToast,
   collections,
   defaultCollectionId = null,
-  token
+  token,
+  workspaceId
 }) {
  const [isModalOpen, setIsModalOpen] = useState(false);
 const [editingPersona, setEditingPersona] = useState(null);
@@ -29,7 +30,7 @@ const [visibleCount, setVisibleCount] = useState(20);
 const [selectedPersonaForRevisions, setSelectedPersonaForRevisions] = useState(null);
 const loadMoreRef = useRef();
 
-const { revisions, loading: loadingRevisions, fetchRevisions } = usePersonaRevisionsApi(token);
+const { revisions, loading: loadingRevisions, fetchRevisions } = usePersonaRevisionsApi(token, workspaceId);
 
   const openRevisionsModal = async (persona) => {
   await fetchRevisions(persona.id);

--- a/src/components/PromptDashboard.jsx
+++ b/src/components/PromptDashboard.jsx
@@ -18,7 +18,8 @@ export default function PromptDashboard({
   showFavoritesOnly,
   sortOption,
   onShowToast,
-  token
+  token,
+  workspaceId
 }) {
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [editingPrompt, setEditingPrompt] = useState(null);
@@ -27,7 +28,7 @@ export default function PromptDashboard({
   const loadMoreRef = useRef();
 
   const [selectedPromptForRevisions, setSelectedPromptForRevisions] = useState(null);
-  const { revisions, loading: loadingRevisions, fetchRevisions } = usePromptRevisionsApi(token);
+  const { revisions, loading: loadingRevisions, fetchRevisions } = usePromptRevisionsApi(token, workspaceId);
 
   const filteredPrompts = prompts
     .filter((prompt) =>

--- a/src/components/RevisionsModal.jsx
+++ b/src/components/RevisionsModal.jsx
@@ -52,10 +52,10 @@ export default function RevisionsModal({
 
   return (
     <Modal isOpen={isOpen} onClose={onClose} size="full" className="w-[95vw]">
-      <div className="w-[95vw] max-h-[90vh] bg-white dark:bg-gray-900 p-6 rounded-xl overflow-hidden flex flex-col gap-6">
+      <div className="w-[95vw] max-h-[90vh] bg-gradient-to-b from-white to-gray-50 dark:from-gray-900 dark:to-gray-800 p-6 rounded-2xl shadow-2xl border border-gray-200 dark:border-gray-700 overflow-hidden flex flex-col gap-6">
 
 
-        <h2 className="text-2xl font-bold text-gray-800 dark:text-white">
+        <h2 className="text-2xl font-bold text-gray-800 dark:text-white tracking-tight">
       {label} Revision History
     </h2>
 
@@ -75,7 +75,7 @@ export default function RevisionsModal({
                 {revisions.map((rev) => (
                   <li
                     key={rev.id}
-                    className={`border rounded-lg p-3 dark:border-gray-700 bg-gray-50 dark:bg-gray-800 ${
+                    className={`border rounded-lg p-3 dark:border-gray-700 bg-gray-50 dark:bg-gray-800 transition hover:bg-gray-100 dark:hover:bg-gray-700 ${
                       selectedRevision?.id === rev.id ? 'ring-2 ring-blue-500' : ''
                     }`}
                   >


### PR DESCRIPTION
## Summary
- pass workspaceId through to persona and prompt dashboards so revision history loads correctly
- refresh revisions modal styling with a modern SaaS look

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_68953dfc8ae08332af65d782daa9beb3