### PR TITLE
feat: enhance marketplace page with header and download

### DIFF
--- a/src/components/ListingCard.jsx
+++ b/src/components/ListingCard.jsx
@@ -1,5 +1,5 @@
 // src/components/ListingCard.jsx
-export default function ListingCard({ item, onFavorite, onClick }) {
+export default function ListingCard({ item, onDownload, onClick }) {
   const price = item.price_cents > 0 ? `€ ${(item.price_cents/100).toFixed(2)}` : 'Free';
 
   return (
@@ -18,10 +18,10 @@ export default function ListingCard({ item, onFavorite, onClick }) {
       <div className="mt-3 flex items-center justify-between">
         <span className="text-sm font-semibold">{price}</span>
         <button
-          className="text-sm px-2 py-1 rounded hover:bg-blue-50 dark:hover:bg-blue-900/30 text-blue-600 dark:text-blue-400"
-          onClick={onFavorite}
+          className="text-sm px-3 py-1 rounded bg-indigo-500 hover:bg-indigo-600 text-white"
+          onClick={onDownload}
         >
-          ♥ Favorite
+          Download
         </button>
       </div>
       <button className="mt-2 text-xs text-gray-500 hover:underline" onClick={onClick}>

--- a/src/pages/Marketplace.jsx
+++ b/src/pages/Marketplace.jsx
@@ -1,7 +1,9 @@
 // src/pages/Marketplace.jsx
 import { useEffect, useState, useCallback } from 'react';
+import { Link } from 'react-router-dom';
 import ListingCard from '../components/ListingCard';
 import UploadModal from '../components/UploadModal';
+import Header from '../components/Header';
 import { useMarketplaceApi } from '../hooks/useMarketplaceApi';
 
 export default function Marketplace({ token }) {
@@ -9,7 +11,7 @@ export default function Marketplace({ token }) {
   const [q, setQ] = useState('');
   const [openUpload, setOpenUpload] = useState(false);
 
-  const { searchListings, toggleFavorite, uploadFile, createListing } = useMarketplaceApi(token);
+  const { searchListings, trackDownload, uploadFile, createListing } = useMarketplaceApi(token);
 
   const load = useCallback(async () => {
     const data = await searchListings({ q, limit: 24, sort: 'recent' });
@@ -25,56 +27,101 @@ export default function Marketplace({ token }) {
   }, [load]);
 
   return (
-    <main className="max-w-6xl mx-auto p-4">
-      <div className="flex items-center justify-between mb-4">
-        <h1 className="text-2xl font-bold">Marketplace</h1>
-        <div className="flex items-center gap-2">
-          <input
-            value={q}
-            onChange={e=>setQ(e.target.value)}
-            placeholder="Search listings..."
-            className="px-3 py-2 rounded border bg-white dark:bg-gray-800 text-sm"
-          />
-          <button className="px-3 py-2 rounded bg-blue-600 text-white" onClick={load}>Search</button>
-          <button className="px-3 py-2 rounded border" onClick={()=>setOpenUpload(true)}>+ New Listing</button>
-        </div>
-      </div>
-
-      <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
-        {items.map(it => (
-          <ListingCard
-            key={it.id}
-            item={it}
-            onFavorite={async ()=> {
-              await toggleFavorite(it.id);
-            }}
-            onClick={()=> alert('TODO: listing details')}
-          />
-        ))}
-      </div>
-
-      {/* Upload -> na upload meteen een listing aanmaken (demo flow) */}
-      <UploadModal
-        open={openUpload}
-        onClose={()=>setOpenUpload(false)}
-        uploadFn={uploadFile}
-        onUploaded={async ({ file_id }) => {
-          const id = await createListing({
-            item_type: 'persona',
-            item_id: 1, // demo; later picker
-            title: 'New Demo Listing',
-            description: 'Uploaded via modal',
-            price_cents: 0,
-            currency: 'EUR',
-            visibility: 'public',
-            tags: 'demo,upload',
-            cover_file_id: file_id
-          });
-          setOpenUpload(false);
-          await load();
-          alert('Listing created: ' + id);
+    <>
+      <Header
+        personas={[]}
+        prompts={[]}
+        searchTerm={q}
+        setSearchTerm={setQ}
+        username=""
+        onOpenProfile={() => {}}
+        createPersona={() => {}}
+        createPrompt={() => {}}
+        fetchPersonas={() => {}}
+        fetchPrompts={() => {}}
+        deletePersona={() => {}}
+        deletePrompt={() => {}}
+        handleUpdateTags={() => {}}
+        onLogout={() => {
+          localStorage.removeItem('vault_jwt_token');
+          window.location.href = '/vault';
         }}
+        isAdmin={false}
+        onOpenAdminPanel={() => {}}
+        onToggleSidebar={() => {}}
       />
-    </main>
+      <main className="min-h-screen bg-gradient-to-br from-indigo-50 via-blue-50 to-purple-50 p-6">
+        <div className="max-w-6xl mx-auto">
+          <div className="flex flex-col sm:flex-row items-center justify-between mb-8 gap-4">
+            <h1 className="text-3xl font-bold text-indigo-700">Marketplace</h1>
+            <Link
+              to="/"
+              className="px-4 py-2 rounded-full bg-indigo-600 text-white hover:bg-indigo-700"
+            >
+              Back to Workspace
+            </Link>
+          </div>
+
+          <div className="flex flex-col sm:flex-row items-center gap-3 mb-8">
+            <input
+              value={q}
+              onChange={e=>setQ(e.target.value)}
+              placeholder="Search listings..."
+              className="flex-1 px-4 py-2 rounded-full border border-indigo-300 bg-white dark:bg-gray-800 text-sm"
+            />
+            <button
+              className="px-4 py-2 rounded-full bg-indigo-500 text-white hover:bg-indigo-600"
+              onClick={load}
+            >
+              Search
+            </button>
+            <button
+              className="px-4 py-2 rounded-full bg-pink-500 text-white hover:bg-pink-600"
+              onClick={()=>setOpenUpload(true)}
+            >
+              + New Listing
+            </button>
+          </div>
+
+          <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
+            {items.map(it => (
+              <ListingCard
+                key={it.id}
+                item={it}
+                onDownload={async () => {
+                  await trackDownload(it.id);
+                  if (it.file_url) window.open(it.file_url, '_blank');
+                }}
+                onClick={()=> alert('TODO: listing details')}
+              />
+            ))}
+          </div>
+
+          {/* Upload -> na upload meteen een listing aanmaken (demo flow) */}
+          <UploadModal
+            open={openUpload}
+            onClose={()=>setOpenUpload(false)}
+            uploadFn={uploadFile}
+            onUploaded={async ({ file_id }) => {
+              const id = await createListing({
+                item_type: 'persona',
+                item_id: 1, // demo; later picker
+                title: 'New Demo Listing',
+                description: 'Uploaded via modal',
+                price_cents: 0,
+                currency: 'EUR',
+                visibility: 'public',
+                tags: 'demo,upload',
+                cover_file_id: file_id
+              });
+              setOpenUpload(false);
+              await load();
+              alert('Listing created: ' + id);
+            }}
+          />
+        </div>
+      </main>
+    </>
   );
 }
+


### PR DESCRIPTION
## Summary
- add standard header and workspace link to marketplace with vibrant SaaS-like styling
- switch listing cards to a free "Download" action

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_6895bb3bc61483328d53fe58e78228f5