### PR TITLE
feat: streamline marketplace listing management

### DIFF
--- a/src/components/ListingCard.jsx
+++ b/src/components/ListingCard.jsx
@@ -1,9 +1,22 @@
 // src/components/ListingCard.jsx
-export default function ListingCard({ item, onFavorite, onClick }) {
+import CardActionsDropdown from './CardActionsDropdown';
+import { FiEdit2, FiTrash2 } from 'react-icons/fi';
+
+export default function ListingCard({ item, onDownload, onClick, onEdit, onDelete }) {
   const price = item.price_cents > 0 ? `€ ${(item.price_cents/100).toFixed(2)}` : 'Free';
 
   return (
-    <div className="bg-white dark:bg-gray-800 rounded-xl shadow hover:shadow-md transition p-3 flex flex-col">
+    <div className="card-container bg-white dark:bg-gray-800 rounded-xl shadow hover:shadow-md transition p-3 flex flex-col relative">
+      {item.is_owner && (
+        <div className="absolute top-2 right-2">
+          <CardActionsDropdown
+            actions={[
+              { label: 'Edit', icon: <FiEdit2 />, onClick: onEdit },
+              { label: 'Delete', icon: <FiTrash2 />, onClick: onDelete, danger: true },
+            ]}
+          />
+        </div>
+      )}
       <div className="aspect-video rounded-lg bg-gray-100 dark:bg-gray-700 overflow-hidden mb-3">
         {item.cover_url ? (
           <img src={item.cover_url} alt={item.title} className="w-full h-full object-cover" />
@@ -18,10 +31,10 @@ export default function ListingCard({ item, onFavorite, onClick }) {
       <div className="mt-3 flex items-center justify-between">
         <span className="text-sm font-semibold">{price}</span>
         <button
-          className="text-sm px-2 py-1 rounded hover:bg-blue-50 dark:hover:bg-blue-900/30 text-blue-600 dark:text-blue-400"
-          onClick={onFavorite}
+          className="text-sm px-3 py-1 rounded bg-indigo-500 hover:bg-indigo-600 text-white"
+          onClick={onDownload}
         >
-          ♥ Favorite
+          Download
         </button>
       </div>
       <button className="mt-2 text-xs text-gray-500 hover:underline" onClick={onClick}>

--- a/src/components/ListingManageModal.jsx
+++ b/src/components/ListingManageModal.jsx
@@ -1,0 +1,121 @@
+// src/components/ListingManageModal.jsx
+import { useState, useEffect } from 'react';
+
+export default function ListingManageModal({ open, onClose, onSave, onDelete, initial = {}, uploadFn }) {
+  const [title, setTitle] = useState('');
+  const [description, setDescription] = useState('');
+  const [price, setPrice] = useState(0);
+  const [itemType, setItemType] = useState('persona');
+  const [coverFileId, setCoverFileId] = useState(null);
+  const [busy, setBusy] = useState(false);
+
+  useEffect(() => {
+    if (initial) {
+      setTitle(initial.title || '');
+      setDescription(initial.description || '');
+      setPrice(initial.price_cents ? initial.price_cents / 100 : 0);
+      setItemType(initial.item_type || 'persona');
+      setCoverFileId(initial.cover_file_id || null);
+    }
+  }, [initial, open]);
+
+  if (!open) return null;
+
+  const handleFile = async (e) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    setBusy(true);
+    try {
+      const res = await uploadFn(file);
+      setCoverFileId(res.file_id);
+    } catch (err) {
+      alert(err.message || 'Upload failed');
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const save = () => {
+    onSave({
+      ...initial,
+      title,
+      description,
+      price_cents: 0,
+      item_type: itemType,
+      cover_file_id: coverFileId,
+    });
+  };
+
+  return (
+    <div className="fixed inset-0 z-50 bg-black/40 flex items-center justify-center" onClick={onClose}>
+      <div className="bg-white dark:bg-gray-900 w-full max-w-lg rounded-xl p-6" onClick={e=>e.stopPropagation()}>
+        <h3 className="text-lg font-semibold mb-4">{initial?.id ? 'Edit Listing' : 'New Listing'}</h3>
+        <div className="space-y-4">
+          <div>
+            <label className="block text-sm mb-1">Title</label>
+            <input
+              className="w-full border rounded px-3 py-2 text-sm"
+              value={title}
+              onChange={e=>setTitle(e.target.value)}
+            />
+          </div>
+          <div>
+            <label className="block text-sm mb-1">Description</label>
+            <textarea
+              className="w-full border rounded px-3 py-2 text-sm"
+              rows="3"
+              value={description}
+              onChange={e=>setDescription(e.target.value)}
+            />
+          </div>
+          <div>
+            <label className="block text-sm mb-1">Type</label>
+            <select
+              className="w-full border rounded px-3 py-2 text-sm"
+              value={itemType}
+              onChange={e=>setItemType(e.target.value)}
+            >
+              <option value="persona">Persona</option>
+              <option value="prompt">Prompt</option>
+            </select>
+          </div>
+          <div>
+            <label className="block text-sm mb-1">Price</label>
+            <input
+              type="number"
+              min="0"
+              value={price}
+              disabled
+              className="w-full border rounded px-3 py-2 text-sm bg-gray-50"
+            />
+            <p className="text-xs text-gray-500 mt-1">Only free listings are supported for now.</p>
+          </div>
+          <div>
+            <label className="block text-sm mb-1">Cover</label>
+            <input type="file" onChange={handleFile} disabled={busy} />
+          </div>
+        </div>
+        <div className="mt-6 flex justify-between">
+          {initial?.id && (
+            <button
+              className="text-sm px-3 py-1.5 rounded border border-red-500 text-red-600 hover:bg-red-50"
+              onClick={() => onDelete && onDelete(initial.id)}
+            >
+              Delete
+            </button>
+          )}
+          <div className="ml-auto space-x-2">
+            <button className="text-sm px-3 py-1.5 rounded border" onClick={onClose}>Cancel</button>
+            <button
+              className="text-sm px-3 py-1.5 rounded bg-indigo-600 text-white hover:bg-indigo-700"
+              onClick={save}
+              disabled={busy}
+            >
+              Save
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/hooks/useMarketplaceApi.js
+++ b/src/hooks/useMarketplaceApi.js
@@ -33,6 +33,16 @@ export function useMarketplaceApi(token) {
     if (!json.success) throw new Error(json.error || 'Update failed');
   };
 
+  const deleteListing = async (listingId) => {
+    const res = await fetch(`${BASE}/marketplace/listings_delete.php`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', ...auth },
+      body: JSON.stringify({ id: listingId }),
+    });
+    const json = await res.json();
+    if (!json.success) throw new Error(json.error || 'Delete failed');
+  };
+
   const toggleFavorite = async (listingId) => {
     const res = await fetch(`${BASE}/marketplace/favorites_toggle.php`, {
       method: 'POST',
@@ -79,5 +89,13 @@ export function useMarketplaceApi(token) {
     });
   };
 
-  return { searchListings, createListing, updateListing, toggleFavorite, uploadFile, trackDownload };
+  return {
+    searchListings,
+    createListing,
+    updateListing,
+    deleteListing,
+    toggleFavorite,
+    uploadFile,
+    trackDownload,
+  };
 }

--- a/src/pages/Marketplace.jsx
+++ b/src/pages/Marketplace.jsx
@@ -1,21 +1,25 @@
 // src/pages/Marketplace.jsx
 import { useEffect, useState, useCallback } from 'react';
+import { Link } from 'react-router-dom';
 import ListingCard from '../components/ListingCard';
-import UploadModal from '../components/UploadModal';
+import ListingManageModal from '../components/ListingManageModal';
+import Header from '../components/Header';
 import { useMarketplaceApi } from '../hooks/useMarketplaceApi';
 
 export default function Marketplace({ token }) {
   const [items, setItems] = useState([]);
   const [q, setQ] = useState('');
-  const [openUpload, setOpenUpload] = useState(false);
+  const [manageOpen, setManageOpen] = useState(false);
+  const [editing, setEditing] = useState(null);
 
-  const { searchListings, toggleFavorite, uploadFile, createListing } = useMarketplaceApi(token);
+  const { searchListings, trackDownload, uploadFile, createListing, updateListing, deleteListing } = useMarketplaceApi(token);
 
   const load = useCallback(async () => {
     const data = await searchListings({ q, limit: 24, sort: 'recent' });
     const mapped = data.map(d => ({
       ...d,
-      cover_url: d.cover_file_id ? `${window.location.origin}/uploads/seed/cover-persona-starter.png` : null
+      cover_url: d.cover_file_id ? `${window.location.origin}/uploads/seed/cover-persona-starter.png` : null,
+      is_owner: d.is_owner,
     }));
     setItems(mapped);
   }, [q, searchListings]);
@@ -25,56 +29,111 @@ export default function Marketplace({ token }) {
   }, [load]);
 
   return (
-    <main className="max-w-6xl mx-auto p-4">
-      <div className="flex items-center justify-between mb-4">
-        <h1 className="text-2xl font-bold">Marketplace</h1>
-        <div className="flex items-center gap-2">
-          <input
-            value={q}
-            onChange={e=>setQ(e.target.value)}
-            placeholder="Search listings..."
-            className="px-3 py-2 rounded border bg-white dark:bg-gray-800 text-sm"
-          />
-          <button className="px-3 py-2 rounded bg-blue-600 text-white" onClick={load}>Search</button>
-          <button className="px-3 py-2 rounded border" onClick={()=>setOpenUpload(true)}>+ New Listing</button>
-        </div>
-      </div>
-
-      <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
-        {items.map(it => (
-          <ListingCard
-            key={it.id}
-            item={it}
-            onFavorite={async ()=> {
-              await toggleFavorite(it.id);
-            }}
-            onClick={()=> alert('TODO: listing details')}
-          />
-        ))}
-      </div>
-
-      {/* Upload -> na upload meteen een listing aanmaken (demo flow) */}
-      <UploadModal
-        open={openUpload}
-        onClose={()=>setOpenUpload(false)}
-        uploadFn={uploadFile}
-        onUploaded={async ({ file_id }) => {
-          const id = await createListing({
-            item_type: 'persona',
-            item_id: 1, // demo; later picker
-            title: 'New Demo Listing',
-            description: 'Uploaded via modal',
-            price_cents: 0,
-            currency: 'EUR',
-            visibility: 'public',
-            tags: 'demo,upload',
-            cover_file_id: file_id
-          });
-          setOpenUpload(false);
-          await load();
-          alert('Listing created: ' + id);
+    <>
+      <Header
+        personas={[]}
+        prompts={[]}
+        searchTerm={q}
+        setSearchTerm={setQ}
+        username=""
+        onOpenProfile={() => {}}
+        createPersona={() => {}}
+        createPrompt={() => {}}
+        fetchPersonas={() => {}}
+        fetchPrompts={() => {}}
+        deletePersona={() => {}}
+        deletePrompt={() => {}}
+        handleUpdateTags={() => {}}
+        onLogout={() => {
+          localStorage.removeItem('vault_jwt_token');
+          window.location.href = '/vault';
         }}
+        isAdmin={false}
+        onOpenAdminPanel={() => {}}
+        onToggleSidebar={() => {}}
       />
-    </main>
+      <main className="min-h-screen bg-gradient-to-br from-indigo-50 via-blue-50 to-purple-50 p-6">
+        <div className="max-w-6xl mx-auto">
+          <div className="flex flex-col sm:flex-row items-center justify-between mb-8 gap-4">
+            <h1 className="text-3xl font-bold text-indigo-700">Marketplace</h1>
+            <Link
+              to="/"
+              className="px-4 py-2 rounded-full bg-indigo-600 text-white hover:bg-indigo-700"
+            >
+              Back to Workspace
+            </Link>
+          </div>
+
+          <div className="flex flex-col sm:flex-row items-center gap-3 mb-8">
+            <input
+              value={q}
+              onChange={e=>setQ(e.target.value)}
+              placeholder="Search listings..."
+              className="flex-1 px-4 py-2 rounded-full border border-indigo-300 bg-white dark:bg-gray-800 text-sm"
+            />
+            <button
+              className="px-4 py-2 rounded-full bg-indigo-500 text-white hover:bg-indigo-600"
+              onClick={load}
+            >
+              Search
+            </button>
+            <button
+              className="px-4 py-2 rounded-full bg-pink-500 text-white hover:bg-pink-600"
+              onClick={()=>{ setEditing(null); setManageOpen(true); }}
+            >
+              + New Listing
+            </button>
+          </div>
+
+          <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
+            {items.map(it => (
+              <ListingCard
+                key={it.id}
+                item={it}
+                onDownload={async () => {
+                  await trackDownload(it.id);
+                  if (it.file_url) window.open(it.file_url, '_blank');
+                }}
+                onClick={()=> alert('TODO: listing details')}
+                onEdit={()=>{ setEditing(it); setManageOpen(true); }}
+                onDelete={async ()=>{
+                  if (confirm('Delete this listing?')) {
+                    await deleteListing(it.id);
+                    await load();
+                  }
+                }}
+              />
+            ))}
+          </div>
+          <ListingManageModal
+            open={manageOpen}
+            onClose={()=>setManageOpen(false)}
+            initial={editing}
+            uploadFn={uploadFile}
+            onSave={async (payload) => {
+              if (payload.id) {
+                await updateListing(payload);
+              } else {
+                await createListing({
+                  ...payload,
+                  item_id: 1,
+                  currency: 'EUR',
+                  visibility: 'public',
+                  tags: '',
+                });
+              }
+              setManageOpen(false);
+              await load();
+            }}
+            onDelete={async (id) => {
+              await deleteListing(id);
+              setManageOpen(false);
+              await load();
+            }}
+          />
+        </div>
+      </main>
+    </>
   );
 }
+


### PR DESCRIPTION
## Summary
- enable listing owners to edit or delete their uploads
- add management modal for creating and updating listings with free-only pricing
- wire marketplace page and API hook for listing removal and editing

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_6895bb3bc61483328d53fe58e78228f5