### PR TITLE
fix: allow admin search across marketplace

### DIFF
--- a/api/marketplace/listings_search.php
+++ b/api/marketplace/listings_search.php
@@ -1,67 +1,83 @@
 <?php
 declare(strict_types=1);
-require __DIR__ . '/../cors.php';
-require __DIR__ . '/../db.php';
 
 header('Content-Type: application/json');
+require __DIR__ . '/../cors.php';
+require __DIR__ . '/../db.php';
+require_once __DIR__ . '/../jwt_utils.php';
 
-$q      = $_GET['q']        ?? '';
-$kind   = $_GET['kind']     ?? ''; // persona|prompt|bundle|asset
-$tag    = $_GET['tag']      ?? '';
+// Optional auth: determine if caller is admin
+$authHeader = $_SERVER['HTTP_AUTHORIZATION'] ?? '';
+$isAdmin = false;
+if (preg_match('/Bearer\s(\S+)/', $authHeader, $matches)) {
+    $decoded = validate_jwt($matches[1]);
+    $isAdmin = $decoded && !empty($decoded['is_admin']);
+}
+
+$q      = $_GET['q']    ?? '';
+$kind   = $_GET['kind'] ?? '';
+$tag    = $_GET['tag']  ?? '';
 $limit  = max(1, min(60, (int)($_GET['limit'] ?? 24)));
 $page   = max(1, (int)($_GET['page'] ?? 1));
 $offset = ($page - 1) * $limit;
-$sort   = $_GET['sort'] ?? 'recent'; // recent|price_asc|price_desc
+$sort   = $_GET['sort'] ?? 'recent';
 
-$wheres = ["status='active'", "visibility='public'"];
+$wheres = [];
 $params = [];
 
+if (!$isAdmin) {
+    $wheres[] = "status='active'";
+    $wheres[] = "visibility='public'";
+}
 if ($kind) {
-  $wheres[] = "item_type = ?";
-  $params[] = $kind;
+    $wheres[] = 'item_type = ?';
+    $params[] = $kind;
 }
 if ($tag) {
-  $wheres[] = "FIND_IN_SET(?, REPLACE(REPLACE(tags,' ',''), ';', ',')) > 0 OR tags LIKE ?";
-  $params[] = $tag;
-  $params[] = '%' . $tag . '%';
+    $wheres[] = "FIND_IN_SET(?, REPLACE(REPLACE(tags,' ',''), ';', ',')) > 0 OR tags LIKE ?";
+    $params[] = $tag;
+    $params[] = '%' . $tag . '%';
 }
 
-$order = "created_at DESC";
-if ($sort === 'price_asc')  $order = "price_cents ASC";
-if ($sort === 'price_desc') $order = "price_cents DESC";
+$order = 'created_at DESC';
+if ($sort === 'price_asc') {
+    $order = 'price_cents ASC';
+}
+if ($sort === 'price_desc') {
+    $order = 'price_cents DESC';
+}
 
 try {
-  if ($q !== '') {
-    // FT (als beschikbaar), anders LIKE
-    $sql = "
-      SELECT id, title, description, price_cents, currency, cover_file_id, item_type
-      FROM marketplace_listings
-      WHERE " . implode(' AND ', $wheres) . "
-        AND (
-          (MATCH(title, description, tags) AGAINST (? IN NATURAL LANGUAGE MODE))
-          OR (title LIKE ? OR description LIKE ?)
-        )
-      ORDER BY $order
-      LIMIT $limit OFFSET $offset
-    ";
-    $paramsFT = array_merge($params, [$q, "%$q%", "%$q%"]);
-    $stmt = $pdo->prepare($sql);
-    $stmt->execute($paramsFT);
-  } else {
-    $sql = "
-      SELECT id, title, description, price_cents, currency, cover_file_id, item_type
-      FROM marketplace_listings
-      WHERE " . implode(' AND ', $wheres) . "
-      ORDER BY $order
-      LIMIT $limit OFFSET $offset
-    ";
-    $stmt = $pdo->prepare($sql);
-    $stmt->execute($params);
-  }
-  $rows = $stmt->fetchAll(PDO::FETCH_ASSOC);
+    $whereSql = $wheres ? 'WHERE ' . implode(' AND ', $wheres) : '';
+    if ($q !== '') {
+        $sql = "
+            SELECT id, title, description, price_cents, currency, cover_file_id, item_type
+            FROM marketplace_listings
+            $whereSql" . ($whereSql ? ' AND ' : ' WHERE ') . "(
+                (MATCH(title, description, tags) AGAINST (? IN NATURAL LANGUAGE MODE))
+                OR (title LIKE ? OR description LIKE ?)
+            )
+            ORDER BY $order
+            LIMIT $limit OFFSET $offset
+        ";
+        $paramsFT = array_merge($params, [$q, "%$q%", "%$q%"]); 
+        $stmt = $pdo->prepare($sql);
+        $stmt->execute($paramsFT);
+    } else {
+        $sql = "
+            SELECT id, title, description, price_cents, currency, cover_file_id, item_type
+            FROM marketplace_listings
+            $whereSql
+            ORDER BY $order
+            LIMIT $limit OFFSET $offset
+        ";
+        $stmt = $pdo->prepare($sql);
+        $stmt->execute($params);
+    }
 
-  echo json_encode(['success' => true, 'items' => $rows]);
+    $rows = $stmt->fetchAll(PDO::FETCH_ASSOC);
+    echo json_encode(['success' => true, 'items' => $rows]);
 } catch (Throwable $e) {
-  http_response_code(500);
-  echo json_encode(['success' => false, 'error' => 'DB error']);
+    http_response_code(500);
+    echo json_encode(['success' => false, 'error' => 'DB error']);
 }

--- a/src/hooks/useMarketplaceApi.js
+++ b/src/hooks/useMarketplaceApi.js
@@ -9,7 +9,8 @@ export function useMarketplaceApi(token) {
 
     try {
       const res = await fetch(`${BASE}/marketplace/listings_search.php?${qs}`, {
-        headers: { ...auth },
+        method: 'GET',
+        headers: { 'Content-Type': 'application/json', ...auth },
       });
       const json = await res.json();
       if (!json.success) throw new Error(json.error || 'Search failed');


### PR DESCRIPTION
## Summary
- handle optional JWT in marketplace listing search so admins can view all items
- send JSON content-type for marketplace listing search requests

## Testing
- `php -l api/marketplace/listings_search.php`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_6895c73f852483328d16630eda36373d