### PR TITLE
feat: allow admins to manage all content

### DIFF
--- a/api/auth_check.php
+++ b/api/auth_check.php
@@ -38,3 +38,8 @@ if (isset($_GET['workspace_id'])) {
         }
     }
 }
+
+// Fetch admin status for further permission checks
+$stmt = $pdo->prepare('SELECT is_admin FROM users WHERE id = ?');
+$stmt->execute([$user_id]);
+$is_admin = (bool) $stmt->fetchColumn();

--- a/api/marketplace/listings_delete.php
+++ b/api/marketplace/listings_delete.php
@@ -24,15 +24,10 @@ try {
         exit;
     }
 
-    if ((int)$owner !== (int)$user_id) {
-        $chk = $pdo->prepare('SELECT is_admin FROM users WHERE id = ?');
-        $chk->execute([$user_id]);
-        $isAdmin = (bool)$chk->fetchColumn();
-        if (!$isAdmin) {
-            http_response_code(403);
-            echo json_encode(['success' => false, 'error' => 'Not allowed']);
-            exit;
-        }
+    if ((int)$owner !== (int)$user_id && !$is_admin) {
+        http_response_code(403);
+        echo json_encode(['success' => false, 'error' => 'Not allowed']);
+        exit;
     }
 
     $del = $pdo->prepare('DELETE FROM marketplace_listings WHERE id = ?');

--- a/api/marketplace/listings_update.php
+++ b/api/marketplace/listings_update.php
@@ -14,7 +14,8 @@ try {
   $check = $pdo->prepare("SELECT seller_user_id FROM marketplace_listings WHERE id=?");
   $check->execute([$id]);
   $owner = $check->fetchColumn();
-  if (!$owner || (int)$owner !== (int)$user_id) {
+  if (!$owner) { http_response_code(404); echo json_encode(['success'=>false,'error'=>'Listing not found']); exit; }
+  if ((int)$owner !== (int)$user_id && !$is_admin) {
     http_response_code(403); echo json_encode(['success'=>false,'error'=>'Not allowed']); exit;
   }
 

--- a/api/personas_delete.php
+++ b/api/personas_delete.php
@@ -13,9 +13,23 @@ if ($id <= 0) {
 }
 
 try {
-    // ✅ Delete alleen als persona bij gebruiker EN workspace hoort
-    $stmt = $pdo->prepare("DELETE FROM personas WHERE id = ? AND user_id = ? AND workspace_id = ?");
-    $stmt->execute([$id, $user_id, $workspace_id]);
+    // ✅ Controleer of persona bestaat en of user eigenaar is (admins mogen alles)
+    if ($is_admin) {
+        $check = $pdo->prepare("SELECT id FROM personas WHERE id = ? AND workspace_id = ?");
+        $check->execute([$id, $workspace_id]);
+    } else {
+        $check = $pdo->prepare("SELECT id FROM personas WHERE id = ? AND user_id = ? AND workspace_id = ?");
+        $check->execute([$id, $user_id, $workspace_id]);
+    }
+
+    if (!$check->fetchColumn()) {
+        http_response_code(403);
+        echo json_encode(['error' => 'Forbidden: You do not have access to this persona']);
+        exit;
+    }
+
+    $stmt = $pdo->prepare("DELETE FROM personas WHERE id = ?");
+    $stmt->execute([$id]);
 
     echo json_encode(['success' => true]);
 } catch (PDOException $e) {

--- a/api/personas_update.php
+++ b/api/personas_update.php
@@ -18,20 +18,47 @@ if (isset($data['collectionIds']) && is_array($data['collectionIds'])) {
     $collectionIds = array_filter(array_map('intval', $data['collectionIds']));
 }
 
-// ✅ Check of de persona van de user én de workspace is
-$checkStmt = $pdo->prepare("SELECT id FROM personas WHERE id = ? AND user_id = ? AND workspace_id = ?");
-$checkStmt->execute([$id, $user_id, $workspace_id]);
-if ($checkStmt->rowCount() === 0) {
+// ✅ Check of de persona bestaat en of de gebruiker eigenaar is (admins mogen alles)
+if ($is_admin) {
+    $checkStmt = $pdo->prepare("SELECT user_id FROM personas WHERE id = ? AND workspace_id = ?");
+    $checkStmt->execute([$id, $workspace_id]);
+} else {
+    $checkStmt = $pdo->prepare("SELECT user_id FROM personas WHERE id = ? AND user_id = ? AND workspace_id = ?");
+    $checkStmt->execute([$id, $user_id, $workspace_id]);
+}
+$ownerId = $checkStmt->fetchColumn();
+if (!$ownerId) {
     http_response_code(403);
     echo json_encode(['error' => 'Unauthorized']);
     exit;
 }
 
 // ✅ Update persona zelf
-$stmt = $pdo->prepare("UPDATE personas 
-    SET name = ?, description = ?, favorite = ?, tags = ?, updated_at = CURRENT_TIMESTAMP 
+$params = [$name, $description, $favorite, $tags, $id];
+if ($is_admin) {
+    $stmt = $pdo->prepare("UPDATE personas
+    SET name = ?, description = ?, favorite = ?, tags = ?, updated_at = CURRENT_TIMESTAMP
+    WHERE id = ? AND workspace_id = ?");
+    $params[] = $workspace_id;
+    $stmt->execute($params);
+    if ($stmt->rowCount() === 0) {
+        http_response_code(404);
+        echo json_encode(['error' => 'Persona not found']);
+        exit;
+    }
+} else {
+    $stmt = $pdo->prepare("UPDATE personas
+    SET name = ?, description = ?, favorite = ?, tags = ?, updated_at = CURRENT_TIMESTAMP
     WHERE id = ? AND user_id = ? AND workspace_id = ?");
-$stmt->execute([$name, $description, $favorite, $tags, $id, $user_id, $workspace_id]);
+    $params[] = $user_id;
+    $params[] = $workspace_id;
+    $stmt->execute($params);
+    if ($stmt->rowCount() === 0) {
+        http_response_code(403);
+        echo json_encode(['error' => 'Unauthorized']);
+        exit;
+    }
+}
 
 // ✅ Sync collections
 try {
@@ -48,7 +75,7 @@ try {
             VALUES (?, ?, ?)
         ");
         foreach ($collectionIds as $colId) {
-            $insertStmt->execute([$id, $colId, $user_id]);
+            $insertStmt->execute([$id, $colId, $ownerId]);
         }
     }
 

--- a/api/prompts_delete.php
+++ b/api/prompts_delete.php
@@ -13,9 +13,14 @@ if ($id <= 0) {
 }
 
 try {
-    // ✅ Controleer of prompt bestaat en behoort tot gebruiker + workspace
-    $checkStmt = $pdo->prepare("SELECT id FROM prompts WHERE id = ? AND user_id = ? AND workspace_id = ?");
-    $checkStmt->execute([$id, $user_id, $workspace_id]);
+    // ✅ Controleer of prompt bestaat en behoort tot gebruiker + workspace (admins mogen alles)
+    if ($is_admin) {
+        $checkStmt = $pdo->prepare("SELECT id FROM prompts WHERE id = ? AND workspace_id = ?");
+        $checkStmt->execute([$id, $workspace_id]);
+    } else {
+        $checkStmt = $pdo->prepare("SELECT id FROM prompts WHERE id = ? AND user_id = ? AND workspace_id = ?");
+        $checkStmt->execute([$id, $user_id, $workspace_id]);
+    }
     $exists = $checkStmt->fetchColumn();
 
     if (!$exists) {

--- a/api/prompts_update.php
+++ b/api/prompts_update.php
@@ -21,11 +21,34 @@ $tags = isset($data['tags']) && is_array($data['tags'])
     : '';
 
 // ✅ Update prompt met gebruikers- én workspace-check
-$stmt = $pdo->prepare("
-    UPDATE prompts 
-    SET title = ?, content = ?, category = ?, favorite = ?, tags = ?, updated_at = CURRENT_TIMESTAMP 
-    WHERE id = ? AND user_id = ? AND workspace_id = ?
-");
-$stmt->execute([$title, $content, $category, $favorite, $tags, $id, $user_id, $workspace_id]);
+$params = [$title, $content, $category, $favorite, $tags, $id];
+if ($is_admin) {
+    $stmt = $pdo->prepare("
+        UPDATE prompts
+        SET title = ?, content = ?, category = ?, favorite = ?, tags = ?, updated_at = CURRENT_TIMESTAMP
+        WHERE id = ? AND workspace_id = ?
+    ");
+    $params[] = $workspace_id;
+    $stmt->execute($params);
+    if ($stmt->rowCount() === 0) {
+        http_response_code(404);
+        echo json_encode(['error' => 'Prompt not found']);
+        exit;
+    }
+} else {
+    $stmt = $pdo->prepare("
+        UPDATE prompts
+        SET title = ?, content = ?, category = ?, favorite = ?, tags = ?, updated_at = CURRENT_TIMESTAMP
+        WHERE id = ? AND user_id = ? AND workspace_id = ?
+    ");
+    $params[] = $user_id;
+    $params[] = $workspace_id;
+    $stmt->execute($params);
+    if ($stmt->rowCount() === 0) {
+        http_response_code(403);
+        echo json_encode(['error' => 'Forbidden: You do not have access to this prompt']);
+        exit;
+    }
+}
 
 echo json_encode(['success' => true]);


### PR DESCRIPTION
## Summary
- expose `is_admin` in `auth_check.php` for centralized privilege checks
- let admins edit or delete any prompt or persona while restricting regular users to their own
- grant admin override on marketplace listing updates and deletions

## Testing
- `npm run lint`
- `php -l api/auth_check.php`
- `php -l api/prompts_delete.php`
- `php -l api/prompts_update.php`
- `php -l api/personas_delete.php`
- `php -l api/personas_update.php`
- `php -l api/marketplace/listings_delete.php`
- `php -l api/marketplace/listings_update.php`


------
https://chatgpt.com/codex/tasks/task_b_6895e4c0a8f083329706be1d3bc6d27c