### PR TITLE
feat: enable marketplace uploads with listing modal

### DIFF
--- a/api/marketplace/listings_search.php
+++ b/api/marketplace/listings_search.php
@@ -102,10 +102,12 @@ try {
             $sql = "
               SELECT l.id, l.title, l.description, l.price_cents, l.currency, l.item_type,
                      l.seller_user_id,
+                     u.username AS seller_name,
                      l.cover_file_id,
                      f.storage_path
               FROM marketplace_listings l
               LEFT JOIN files f ON f.id = l.cover_file_id
+              LEFT JOIN users u ON u.id = l.seller_user_id
               $whereSql" . ($whereSql ? ' AND ' : ' WHERE ') . "(
                 (MATCH(l.title, l.description, l.tags) AGAINST (? IN NATURAL LANGUAGE MODE))
                 OR (l.title LIKE ? OR l.description LIKE ?)
@@ -119,10 +121,12 @@ try {
             $sql = "
               SELECT l.id, l.title, l.description, l.price_cents, l.currency, l.item_type,
                      l.seller_user_id,
+                     u.username AS seller_name,
                      l.cover_file_id,
                      f.storage_path
               FROM marketplace_listings l
               LEFT JOIN files f ON f.id = l.cover_file_id
+              LEFT JOIN users u ON u.id = l.seller_user_id
               $whereSql" . ($whereSql ? ' AND ' : ' WHERE ') . "(
                 l.title LIKE ? OR l.description LIKE ?
               )
@@ -137,10 +141,12 @@ try {
         $sql = "
           SELECT l.id, l.title, l.description, l.price_cents, l.currency, l.item_type,
                  l.seller_user_id,
+                 u.username AS seller_name,
                  l.cover_file_id,
                  f.storage_path
           FROM marketplace_listings l
           LEFT JOIN files f ON f.id = l.cover_file_id
+          LEFT JOIN users u ON u.id = l.seller_user_id
           $whereSql
           ORDER BY $order
           LIMIT $limit OFFSET $offset

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -637,8 +637,7 @@ const handleUpdateTags = ({ action, targetTag, newTag, sourceTag }) => {
   setIsPersonaModalOpen(true);
   setGlobalToastMessage(`Editing persona "${fullPersona.name}"...`);
 }}
-
-
+  token={token}
 />
 
 

--- a/src/components/ListingCard.jsx
+++ b/src/components/ListingCard.jsx
@@ -31,6 +31,9 @@ export default function ListingCard({ item, onDownload, onClick, onEdit, onDelet
       <div className="flex-1">
         <h3 className="font-semibold text-gray-800 dark:text-gray-100 line-clamp-2">{item.title}</h3>
         <p className="text-xs text-gray-500 dark:text-gray-400 mt-1 capitalize">{item.item_type}</p>
+        {item.seller_name && (
+          <p className="text-xs text-gray-500 dark:text-gray-400 mt-1">By {item.seller_name}</p>
+        )}
       </div>
       <div className="mt-3 flex items-center justify-between">
         <span className="text-sm font-semibold">{price}</span>

--- a/src/components/PersonaDashboard.jsx
+++ b/src/components/PersonaDashboard.jsx
@@ -5,6 +5,8 @@ import Button from './Button';
 import { useState, useEffect, useRef } from 'react';
 import { usePersonaRevisionsApi } from '../hooks/usePersonaRevisionsApi';
 import RevisionsModal from './RevisionsModal';
+import ListingManageModal from './ListingManageModal';
+import { useMarketplaceApi } from '../hooks/useMarketplaceApi';
 
 export default function PersonaDashboard({
   personas,
@@ -31,6 +33,10 @@ const [selectedPersonaForRevisions, setSelectedPersonaForRevisions] = useState(n
 const loadMoreRef = useRef();
 
 const { revisions, loading: loadingRevisions, fetchRevisions } = usePersonaRevisionsApi(token, workspaceId);
+
+const { createListing, uploadFile } = useMarketplaceApi(token);
+const [uploadingPersona, setUploadingPersona] = useState(null);
+const stripHtml = (html = '') => html.replace(/<[^>]*>/g, '');
 
   const openRevisionsModal = async (persona) => {
   await fetchRevisions(persona.id);
@@ -194,7 +200,7 @@ const { revisions, loading: loadingRevisions, fetchRevisions } = usePersonaRevis
               onEdit={startEdit}
               onShowToast={onShowToast}
               onViewRevisions={() => openRevisionsModal(persona)}
-              onUpload={() => onShowToast('Uploaded to marketplace!')}
+              onUpload={(p) => setUploadingPersona(p)}
             />
           ))}
         </div>
@@ -240,7 +246,7 @@ const { revisions, loading: loadingRevisions, fetchRevisions } = usePersonaRevis
 />
       </Modal>
 
-      <RevisionsModal
+  <RevisionsModal
   isOpen={!!selectedPersonaForRevisions}
   onClose={() => setSelectedPersonaForRevisions(null)}
   revisions={revisions}
@@ -259,6 +265,24 @@ const { revisions, loading: loadingRevisions, fetchRevisions } = usePersonaRevis
     setSelectedPersonaForRevisions(null);
   }}
 />
+
+      <ListingManageModal
+        open={!!uploadingPersona}
+        onClose={() => setUploadingPersona(null)}
+        initial={uploadingPersona ? {
+          title: uploadingPersona.name,
+          description: stripHtml(uploadingPersona.description),
+          item_type: 'persona',
+          item_id: uploadingPersona.id,
+          tags: Array.isArray(uploadingPersona.tags) ? uploadingPersona.tags.join(',') : (uploadingPersona.tags || ''),
+        } : {}}
+        uploadFn={uploadFile}
+        onSave={async (payload) => {
+          await createListing({ ...payload, currency: 'EUR', visibility: 'public' });
+          setUploadingPersona(null);
+          onShowToast('Uploaded to marketplace!');
+        }}
+      />
 
     </div>
   );

--- a/src/components/PromptDashboard.jsx
+++ b/src/components/PromptDashboard.jsx
@@ -4,10 +4,12 @@ import PromptCard from './PromptCard';
 import Button from './Button';
 import RevisionsModal from './RevisionsModal'; // 👈 nieuwe component
 import Tooltip from './Tooltip';
+import ListingManageModal from './ListingManageModal';
 
 
 import { useState, useEffect, useRef } from 'react';
 import { usePromptRevisionsApi } from '../hooks/usePromptRevisionsApi';
+import { useMarketplaceApi } from '../hooks/useMarketplaceApi';
 
 export default function PromptDashboard({
   prompts,
@@ -32,6 +34,10 @@ export default function PromptDashboard({
 
   const [selectedPromptForRevisions, setSelectedPromptForRevisions] = useState(null);
   const { revisions, loading: loadingRevisions, fetchRevisions } = usePromptRevisionsApi(token, workspaceId);
+
+  const { createListing, uploadFile } = useMarketplaceApi(token);
+  const [uploadingPrompt, setUploadingPrompt] = useState(null);
+  const stripHtml = (html = '') => html.replace(/<[^>]*>/g, '');
 
   const filteredPrompts = prompts
     .filter((prompt) =>
@@ -140,7 +146,7 @@ export default function PromptDashboard({
               onEdit={startEdit}
               onViewRevisions={() => openRevisionsModal(prompt)}
               onShowToast={onShowToast}
-              onUpload={() => onShowToast('Uploaded to marketplace!')}
+              onUpload={(prompt) => setUploadingPrompt(prompt)}
             />
           ))}
         </div>
@@ -191,6 +197,24 @@ export default function PromptDashboard({
           await fetchPrompts();
           onShowToast('Prompt rolled back to revision.');
           setSelectedPromptForRevisions(null);
+        }}
+      />
+
+      <ListingManageModal
+        open={!!uploadingPrompt}
+        onClose={() => setUploadingPrompt(null)}
+        initial={uploadingPrompt ? {
+          title: uploadingPrompt.title,
+          description: stripHtml(uploadingPrompt.content),
+          item_type: 'prompt',
+          item_id: uploadingPrompt.id,
+          tags: Array.isArray(uploadingPrompt.tags) ? uploadingPrompt.tags.join(',') : (uploadingPrompt.tags || ''),
+        } : {}}
+        uploadFn={uploadFile}
+        onSave={async (payload) => {
+          await createListing({ ...payload, currency: 'EUR', visibility: 'public' });
+          setUploadingPrompt(null);
+          onShowToast('Uploaded to marketplace!');
         }}
       />
     </div>

--- a/src/pages/CollectionPage.jsx
+++ b/src/pages/CollectionPage.jsx
@@ -2,6 +2,8 @@ import { useState, useMemo } from 'react';
 import Button from '../components/Button';
 import PersonaCard from '../components/PersonaCard';
 import AddExistingPersonaModal from './AddExistingPersonaModal';
+import ListingManageModal from '../components/ListingManageModal';
+import { useMarketplaceApi } from '../hooks/useMarketplaceApi';
 
 export default function CollectionPage({
   collectionId,
@@ -15,8 +17,12 @@ export default function CollectionPage({
   onDeletePersona,
   onStartEditPersona,
   onShowToast,
+  token,
 }) {
   const [isAddPersonaModalOpen, setIsAddPersonaModalOpen] = useState(false);
+  const { createListing, uploadFile } = useMarketplaceApi(token);
+  const [uploadingPersona, setUploadingPersona] = useState(null);
+  const stripHtml = (html = '') => html.replace(/<[^>]*>/g, '');
 
   const personasInCollection = useMemo(() => {
   if (!collectionId || !Array.isArray(personas)) return [];
@@ -71,7 +77,7 @@ export default function CollectionPage({
       <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
         {personasInCollection.map((persona) => (
   <div key={persona.id} className="relative flex flex-col border rounded-xl shadow-sm dark:border-gray-700 bg-white dark:bg-gray-900 overflow-hidden">
-    
+
     {/* PersonaCard zonder eigen padding, maar met content */}
     <div className="p-4 pb-2">
       <PersonaCard
@@ -81,7 +87,7 @@ export default function CollectionPage({
         onDelete={() => onDeletePersona(persona.id)}
         onEdit={() => onStartEditPersona(persona)}
         onShowToast={onShowToast}
-        onUpload={() => onShowToast('Uploaded to marketplace!')}
+        onUpload={(p) => setUploadingPersona(p)}
         compactMode // optioneel activeren voor consistente hoogte
       />
     </div>
@@ -111,6 +117,24 @@ export default function CollectionPage({
         onAssignPersonasToCollection(personaIds, collectionId);
         onShowToast('Personas toegevoegd aan collectie!');
         setIsAddPersonaModalOpen(false);
+      }}
+    />
+
+    <ListingManageModal
+      open={!!uploadingPersona}
+      onClose={() => setUploadingPersona(null)}
+      initial={uploadingPersona ? {
+        title: uploadingPersona.name,
+        description: stripHtml(uploadingPersona.description),
+        item_type: 'persona',
+        item_id: uploadingPersona.id,
+        tags: Array.isArray(uploadingPersona.tags) ? uploadingPersona.tags.join(',') : (uploadingPersona.tags || ''),
+      } : {}}
+      uploadFn={uploadFile}
+      onSave={async (payload) => {
+        await createListing({ ...payload, currency: 'EUR', visibility: 'public' });
+        setUploadingPersona(null);
+        onShowToast('Uploaded to marketplace!');
       }}
     />
   </div>


### PR DESCRIPTION
## Summary
- show listing uploader name in search results
- open listing details modal when uploading personas or prompts
- allow uploading from collections as well

## Testing
- `npm run lint`
- `php -l api/marketplace/listings_search.php`


------
https://chatgpt.com/codex/tasks/task_b_6895e88d183083329c5f7622b99b840a