### PR TITLE
feat: add slide-out listing details modal

### DIFF
--- a/src/components/ListingDetailsModal.jsx
+++ b/src/components/ListingDetailsModal.jsx
@@ -1,0 +1,48 @@
+// src/components/ListingDetailsModal.jsx
+import React from 'react';
+
+export default function ListingDetailsModal({ item, onClose, onDownload }) {
+  const price = item.price_cents > 0 ? `€ ${(item.price_cents / 100).toFixed(2)}` : 'Free';
+
+  return (
+    <div className="absolute left-0 top-full mt-2 w-full z-50">
+      <div className="relative bg-white dark:bg-gray-800 rounded-xl shadow-xl p-6 animate-slideUp">
+        <button
+          className="absolute top-2 right-2 text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200"
+          onClick={onClose}
+        >
+          ×
+        </button>
+        <h3 className="text-xl font-bold mb-1 text-gray-800 dark:text-gray-100">{item.title}</h3>
+        {item.seller_name && (
+          <p className="text-sm text-gray-500 dark:text-gray-400 mb-2">By {item.seller_name}</p>
+        )}
+        <p className="text-sm text-gray-600 dark:text-gray-300 mb-4 whitespace-pre-line">{item.description}</p>
+        <div className="flex items-center justify-between">
+          <span className="text-sm font-semibold">{price}</span>
+          <button
+            className="text-sm px-4 py-2 rounded bg-indigo-500 hover:bg-indigo-600 text-white"
+            onClick={onDownload}
+          >
+            Download
+          </button>
+        </div>
+      </div>
+      <style jsx="true">{`
+        @keyframes slideUp {
+          from {
+            opacity: 0;
+            transform: translateY(10px);
+          }
+          to {
+            opacity: 1;
+            transform: translateY(0);
+          }
+        }
+        .animate-slideUp {
+          animation: slideUp 0.25s ease-out forwards;
+        }
+      `}</style>
+    </div>
+  );
+}

--- a/src/pages/Marketplace.jsx
+++ b/src/pages/Marketplace.jsx
@@ -6,6 +6,7 @@ import { jwtDecode } from 'jwt-decode';
 import Header from '../components/Header';
 import ListingCard from '../components/ListingCard';
 import ListingManageModal from '../components/ListingManageModal';
+import ListingDetailsModal from '../components/ListingDetailsModal';
 import { useMarketplaceApi } from '../hooks/useMarketplaceApi';
 
 const PLACEHOLDER = '/logo-512.png'; // fallback als geen cover_url
@@ -15,6 +16,7 @@ export default function Marketplace({ token }) {
   const [q, setQ] = useState('');
   const [manageOpen, setManageOpen] = useState(false);
   const [editing, setEditing] = useState(null);
+  const [active, setActive] = useState(null);
   const [isAdmin, setIsAdmin] = useState(false);
 
   const didInit = useRef(false);
@@ -113,23 +115,34 @@ export default function Marketplace({ token }) {
 
           <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
             {items.map((it) => (
-              <ListingCard
-                key={it.id}
-                item={it}
-                canManage={it.is_owner || isAdmin}
-                onDownload={async () => {
-                  await trackDownload(it.id);
-                  if (it.file_url) window.open(it.file_url, '_blank', 'noopener');
-                }}
-                onClick={() => alert('TODO: listing details')}
-                onEdit={() => { setEditing(it); setManageOpen(true); }}
-                onDelete={async () => {
-                  if (confirm('Delete this listing?')) {
-                    await deleteListing(it.id);
-                    await load();
-                  }
-                }}
-              />
+              <div key={it.id} className="relative">
+                <ListingCard
+                  item={it}
+                  canManage={it.is_owner || isAdmin}
+                  onDownload={async () => {
+                    await trackDownload(it.id);
+                    if (it.file_url) window.open(it.file_url, '_blank', 'noopener');
+                  }}
+                  onClick={() => setActive(active?.id === it.id ? null : it)}
+                  onEdit={() => { setEditing(it); setManageOpen(true); }}
+                  onDelete={async () => {
+                    if (confirm('Delete this listing?')) {
+                      await deleteListing(it.id);
+                      await load();
+                    }
+                  }}
+                />
+                {active?.id === it.id && (
+                  <ListingDetailsModal
+                    item={active}
+                    onClose={() => setActive(null)}
+                    onDownload={async () => {
+                      await trackDownload(it.id);
+                      if (it.file_url) window.open(it.file_url, '_blank', 'noopener');
+                    }}
+                  />
+                )}
+              </div>
             ))}
           </div>
 


### PR DESCRIPTION
## Summary
- add ListingDetailsModal component with animated slide-up design
- integrate details modal into Marketplace and toggle via card actions

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_6895ebfbad5c8332b604c54943c12bf1