### PR TITLE
fix: improve workspace responsiveness

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -427,7 +427,7 @@ const handleUpdateTags = ({ action, targetTag, newTag, sourceTag }) => {
 
 {workspaces.length > 0 && (
   <>
-  <div className="max-w-screen-xl mx-auto px-2 sm:px-4 mb-2 mt-4 flex justify-between items-center">
+  <div className="max-w-screen-xl mx-auto px-2 sm:px-4 mb-2 mt-4 flex flex-col sm:flex-row justify-between items-center gap-2">
     <div className="flex items-center space-x-2 text-sm">
       <label htmlFor="workspaceSelect" className="text-gray-700 dark:text-gray-300 font-medium">
         Workspace:
@@ -459,9 +459,9 @@ const handleUpdateTags = ({ action, targetTag, newTag, sourceTag }) => {
       </div>
     </div>
 
-    <div className="flex items-center">
+    <div className="flex flex-wrap justify-center gap-2 mt-2 sm:mt-0 w-full sm:w-auto">
       <button
-        className="ml-4 mt-2 px-3 py-1.5 bg-blue-600 text-white rounded text-sm hover:bg-blue-700 transition-all"
+        className="w-full sm:w-auto px-3 py-1.5 bg-blue-600 text-white rounded text-sm hover:bg-blue-700 transition-all"
         onClick={() => {
           const name = prompt('Name your workspace:');
           if (name && name.trim().length > 1) {
@@ -475,7 +475,7 @@ const handleUpdateTags = ({ action, targetTag, newTag, sourceTag }) => {
         + New workspace
       </button>
       <button
-        className="ml-2 mt-2 px-3 py-1.5 bg-gray-600 text-white rounded text-sm hover:bg-gray-700 transition-all"
+        className="w-full sm:w-auto px-3 py-1.5 bg-gray-600 text-white rounded text-sm hover:bg-gray-700 transition-all"
         onClick={async () => {
           try {
             const res = await fetch(`${import.meta.env.VITE_API_BASE_URL}/workspaces_share_create.php`, {
@@ -524,7 +524,7 @@ const handleUpdateTags = ({ action, targetTag, newTag, sourceTag }) => {
         />
       </div>
 
-      <div className="max-w-screen-xl mx-auto px-2 sm:px-4 mb-4 flex flex-wrap gap-2 items-center">
+  <div className="max-w-screen-xl mx-auto px-2 sm:px-4 mb-4 flex flex-wrap gap-2 items-center justify-center">
   <TagFilterDropdown
     tags={[...personas.map((p) => p.tags || []), ...prompts.map((p) => p.tags || [])]}
     activeTags={activeTags}

--- a/src/components/QuickTitlesDropdown.jsx
+++ b/src/components/QuickTitlesDropdown.jsx
@@ -27,7 +27,7 @@ export default function QuickTitlesDropdown({ personaItems, promptItems, onShowT
   }, []);
 
   return (
-    <div className="relative inline-block text-left mb-6" ref={dropdownRef}>
+    <div className="relative inline-block mb-6" ref={dropdownRef}>
       {/* Trigger button */}
       <button
         onClick={() => setIsOpen(!isOpen)}

--- a/src/components/Sidebar.jsx
+++ b/src/components/Sidebar.jsx
@@ -1,11 +1,13 @@
 // src/components/Sidebar.jsx
 
 import React from 'react';
+import { Link } from 'react-router-dom';
 import {
   FiUsers,
   FiFileText,
   FiFolder,
   FiChevronLeft,
+  FiShoppingBag,
 } from 'react-icons/fi';
 
 export default function Sidebar({ selectedTab, setSelectedTab, isOpen, setIsOpen }) {
@@ -14,6 +16,7 @@ export default function Sidebar({ selectedTab, setSelectedTab, isOpen, setIsOpen
     { id: 'personas', icon: FiUsers, label: 'Personas' },
     { id: 'prompts', icon: FiFileText, label: 'Prompts' },
     { id: 'collections', icon: FiFolder, label: 'Collections' },
+    { id: 'marketplace', icon: FiShoppingBag, label: 'Marketplace', href: '/marketplace' },
   ];
 
   return (
@@ -42,21 +45,26 @@ export default function Sidebar({ selectedTab, setSelectedTab, isOpen, setIsOpen
       >
         {/* Navigatieknoppen */}
         <div className="flex flex-col items-center space-y-6">
-          {navItems.map(({ id, icon, label }) => {
+          {navItems.map(({ id, icon, label, href }) => {
             const active = selectedTab === id;
-            return (
-              <button
-                key={id}
-                type="button"
-                onClick={() => setSelectedTab(id)}
-                title={label}
-                className={`
+            const classes = `
                   p-3 rounded-xl transition-colors
                   ${active
                     ? 'text-blue-600 bg-blue-100 dark:bg-blue-900/50'
                     : 'text-gray-500 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white hover:bg-gray-100 dark:hover:bg-gray-700'
                   }
-                `}
+                `;
+            return href ? (
+              <Link key={id} to={href} title={label} className={classes}>
+                {React.createElement(icon, { className: 'w-6 h-6' })}
+              </Link>
+            ) : (
+              <button
+                key={id}
+                type="button"
+                onClick={() => setSelectedTab(id)}
+                title={label}
+                className={classes}
               >
                 {React.createElement(icon, { className: 'w-6 h-6' })}
               </button>

--- a/src/components/TagFilterDropdown.jsx
+++ b/src/components/TagFilterDropdown.jsx
@@ -31,7 +31,7 @@ export default function TagFilterDropdown({ tags, activeTags, onTagToggle }) {
   }, []);
 
   return (
-    <div className="relative inline-block text-left mb-6 mr-4" ref={dropdownRef}>
+    <div className="relative inline-block mb-6" ref={dropdownRef}>
       {/* Trigger button */}
       <button
         onClick={() => setIsOpen(!isOpen)}


### PR DESCRIPTION
## Summary
- center tag filter and quick titles section for better mobile layout
- make workspace actions responsive and full-width on small screens
- add marketplace shortcut with icon to the sidebar

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_68963ff569f88332802d3eda65ea27ce