### PR TITLE
feat: persist profile data and allow password update

### DIFF
--- a/api/profile_get.php
+++ b/api/profile_get.php
@@ -1,0 +1,17 @@
+<?php
+header('Content-Type: application/json');
+include 'cors.php';
+include 'db.php';
+require_once 'auth_check.php';
+
+$stmt = $pdo->prepare('SELECT username, email, profile_name, address, role, photo FROM users WHERE id = ?');
+$stmt->execute([$user_id]);
+$profile = $stmt->fetch(PDO::FETCH_ASSOC);
+
+if (!$profile) {
+    http_response_code(404);
+    echo json_encode(['error' => 'User not found']);
+    exit;
+}
+
+echo json_encode(['success' => true, 'profile' => $profile]);

--- a/api/profile_update.php
+++ b/api/profile_update.php
@@ -1,0 +1,69 @@
+<?php
+header('Content-Type: application/json');
+include 'cors.php';
+include 'db.php';
+require_once 'auth_check.php';
+
+$data = json_decode(file_get_contents('php://input'), true);
+
+$name = trim($data['name'] ?? '');
+$address = trim($data['address'] ?? '');
+$email = trim($data['email'] ?? '');
+$role = trim($data['role'] ?? '');
+$photo = $data['photo'] ?? '';
+$currentPassword = $data['currentPassword'] ?? '';
+$newPassword = $data['newPassword'] ?? '';
+
+$fields = [];
+$params = [];
+
+if ($name !== '') {
+    $fields[] = 'profile_name = ?';
+    $params[] = $name;
+}
+if ($address !== '') {
+    $fields[] = 'address = ?';
+    $params[] = $address;
+}
+if ($email !== '') {
+    $fields[] = 'email = ?';
+    $params[] = $email;
+}
+if ($role !== '') {
+    $fields[] = 'role = ?';
+    $params[] = $role;
+}
+if ($photo !== '') {
+    $fields[] = 'photo = ?';
+    $params[] = $photo;
+}
+
+if ($newPassword !== '') {
+    if (!$currentPassword) {
+        http_response_code(400);
+        echo json_encode(['error' => 'Current password required']);
+        exit;
+    }
+    $stmt = $pdo->prepare('SELECT password_hash FROM users WHERE id = ?');
+    $stmt->execute([$user_id]);
+    $hash = $stmt->fetchColumn();
+    if (!$hash || !password_verify($currentPassword, $hash)) {
+        http_response_code(400);
+        echo json_encode(['error' => 'Current password incorrect']);
+        exit;
+    }
+    $fields[] = 'password_hash = ?';
+    $params[] = password_hash($newPassword, PASSWORD_DEFAULT);
+}
+
+if (empty($fields)) {
+    echo json_encode(['success' => true]);
+    exit;
+}
+
+$params[] = $user_id;
+$sql = 'UPDATE users SET ' . implode(', ', $fields) . ' WHERE id = ?';
+$stmt = $pdo->prepare($sql);
+$stmt->execute($params);
+
+echo json_encode(['success' => true]);

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -773,6 +773,7 @@ workspaceId={activeWorkspaceId}
 
       {isProfileModalOpen && decodedToken && (
   <ProfileModal
+  token={token}
   decodedToken={decodedToken}
   personaCount={personaCount}
   personas={personas}   // <--- DIT TOEVOEGEN

--- a/src/components/ProfileModal.jsx
+++ b/src/components/ProfileModal.jsx
@@ -7,6 +7,7 @@ import OnboardingChecklist from './OnboardingChecklist';
 import Input from './Input';
 
 export default function ProfileModal({
+  token,
   decodedToken,
   onLogout,
   onClose,
@@ -29,15 +30,34 @@ export default function ProfileModal({
   const [profileEmail, setProfileEmail] = useState('');
   const [role, setRole] = useState('');
   const [photo, setPhoto] = useState('');
+  const [currentPassword, setCurrentPassword] = useState('');
+  const [newPassword, setNewPassword] = useState('');
+  const [confirmPassword, setConfirmPassword] = useState('');
+  const [error, setError] = useState('');
 
-  // Load stored profile info
+  // Fetch stored profile info from API
   useEffect(() => {
-    setName(localStorage.getItem('vault_profile_name') || username || '');
-    setAddress(localStorage.getItem('vault_profile_address') || '');
-    setProfileEmail(localStorage.getItem('vault_profile_email') || email || '');
-    setRole(localStorage.getItem('vault_profile_role') || '');
-    setPhoto(localStorage.getItem('vault_profile_photo') || '');
-  }, [username, email]);
+    async function loadProfile() {
+      try {
+        const res = await fetch('/api/profile_get.php', {
+          headers: { Authorization: `Bearer ${token}` }
+        });
+        const data = await res.json();
+        if (data.profile) {
+          setName(data.profile.profile_name || username || '');
+          setAddress(data.profile.address || '');
+          setProfileEmail(data.profile.email || email || '');
+          setRole(data.profile.role || '');
+          setPhoto(data.profile.photo || '');
+        }
+      } catch (e) {
+        console.error('Failed to load profile', e);
+      }
+    }
+    if (token) {
+      loadProfile();
+    }
+  }, [token, username, email]);
 
   const handlePhotoChange = (e) => {
     const file = e.target.files?.[0];
@@ -50,17 +70,44 @@ export default function ProfileModal({
     reader.readAsDataURL(file);
   };
 
-  const handleSave = (e) => {
+  const handleSave = async (e) => {
     e.preventDefault();
-    localStorage.setItem('vault_profile_name', name);
-    localStorage.setItem('vault_profile_address', address);
-    localStorage.setItem('vault_profile_email', profileEmail);
-    localStorage.setItem('vault_profile_role', role);
-    if (photo) {
-      localStorage.setItem('vault_profile_photo', photo);
+    setError('');
+    if (newPassword && newPassword !== confirmPassword) {
+      setError('New passwords do not match');
+      return;
     }
-    localStorage.setItem('vault_onboard_completedProfile', '1');
-    setActiveTab('overview');
+    try {
+      const res = await fetch('/api/profile_update.php', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${token}`
+        },
+        body: JSON.stringify({
+          name,
+          address,
+          email: profileEmail,
+          role,
+          photo,
+          currentPassword,
+          newPassword
+        })
+      });
+      const data = await res.json();
+      if (data.error) {
+        setError(data.error);
+        return;
+      }
+      localStorage.setItem('vault_onboard_completedProfile', '1');
+      setActiveTab('overview');
+      setCurrentPassword('');
+      setNewPassword('');
+      setConfirmPassword('');
+    } catch (err) {
+      console.error('Failed to save profile', err);
+      setError('Failed to save profile');
+    }
   };
 
   // ✅ Auto-mark onboarding stappen op basis van je data
@@ -237,6 +284,25 @@ export default function ProfileModal({
                 />
               )}
             </div>
+            {error && <p className="text-red-500 text-sm">{error}</p>}
+            <Input
+              label="Current password"
+              type="password"
+              value={currentPassword}
+              onChange={(e) => setCurrentPassword(e.target.value)}
+            />
+            <Input
+              label="New password"
+              type="password"
+              value={newPassword}
+              onChange={(e) => setNewPassword(e.target.value)}
+            />
+            <Input
+              label="Confirm new password"
+              type="password"
+              value={confirmPassword}
+              onChange={(e) => setConfirmPassword(e.target.value)}
+            />
             <div className="flex justify-end space-x-2 pt-2">
               <Button
                 variant="outline"


### PR DESCRIPTION
## Summary
- store profile information server-side and sync on load
- allow users to update their password from profile modal
- expose new API endpoints for profile fetch and update

## Testing
- `npm run lint`
- `php -l api/profile_get.php`
- `php -l api/profile_update.php`


------
https://chatgpt.com/codex/tasks/task_b_68964257c0548332bfd009a55e7555b4